### PR TITLE
CRR-518 add crr-risk-factor-anomaly-detection to NAB

### DIFF
--- a/workflow-init/profile/nab.yml
+++ b/workflow-init/profile/nab.yml
@@ -228,18 +228,18 @@ component:
         kustomize:
           overlays: *defaultOverlays
           path: plattform/processing/crr-risk-factors/crr-risk-factor-payment-means
-     # NOT YET READY, THERE IS AN ISSUE WITH PREFIX - DOES NOT WORK IF DIFFERENT THAN IN MODULES ABOVE
-     #crr-risk-factor-anomaly-detection:
-     #  parameters:
-     #    <<: *defaultParameters
-     #    kustomize: github
-     #  ecr:
-     #    <<: *defaultECR
-     #    repository: hawkai-crr-risk-factor-anomaly-detection
-     #    repository-prefix: hawkai-
-     #  kustomize:
-     #    overlays: *defaultOverlays
-     #    path: plattform/processing/crr-risk-factors/crr-risk-factor-anomaly-detection
+     crr-risk-factor-anomaly-detection:
+      parameters:
+        <<: *defaultParameters
+        kustomize: github
+        java-version: 17
+      ecr:
+        <<: *defaultECR
+        repository: hawk-crr-risk-factor-anomaly-detection
+        repository-prefix: hawk-
+      kustomize:
+        overlays: *defaultOverlays
+        path: plattform/processing/crr-risk-factors/crr-risk-factor-anomaly-detection
 
   customer-risk-rating-events-sink:
     parameters:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/108131770/218474382-5c733ff6-6ff5-44de-802c-b9abf5249abd.png)

prefix of ECR image on NAB is now fixed from `hawkai` to `hawk` 

we should now be able to tag `crr-risk-factor-anomaly-detection` for NAB