### PR TITLE
Revert "Upgrade gateway to Java 17"

### DIFF
--- a/workflow-init/profile/hawk.yml
+++ b/workflow-init/profile/hawk.yml
@@ -393,7 +393,6 @@ component:
     parameters:
       <<: *defaultParameters
       kustomize: github
-      java-version: 17
     ecr:
       <<: *defaultECR
     kustomize:
@@ -403,17 +402,14 @@ component:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
       engine:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
       msg:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
         ecr:
           <<: *defaultECR
           repository: hawkai-gateway-msg
@@ -424,7 +420,6 @@ component:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
         ecr:
           <<: *defaultECR
           repository: hawkai-gateway-batch
@@ -435,7 +430,6 @@ component:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
         ecr:
           <<: *defaultECR
           repository: hawkai-gateway
@@ -446,7 +440,6 @@ component:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
         ecr:
           <<: *defaultECR
           repository: hawkai-gateway-activemq

--- a/workflow-init/profile/nab.yml
+++ b/workflow-init/profile/nab.yml
@@ -354,7 +354,6 @@ component:
     parameters:
       <<: *defaultParameters
       kustomize: github
-      java-version: 17
     ecr:
       <<: *defaultECR
       repository-prefix: hawk-
@@ -365,17 +364,14 @@ component:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
       engine:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
       msg:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
         ecr:
           <<: *defaultECR
           repository: hawk-hawkai-gateway-msg
@@ -387,7 +383,6 @@ component:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
         ecr:
           <<: *defaultECR
           repository: hawk-hawkai-gateway-batch
@@ -399,7 +394,6 @@ component:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
         ecr:
           <<: *defaultECR
           repository: hawk-hawkai-gateway
@@ -411,7 +405,6 @@ component:
         parameters:
           <<: *defaultParameters
           kustomize: github
-          java-version: 17
 
   features:
     parameters:


### PR DESCRIPTION
This reverts commit 9571e5d1f326310e3736981e4ce4f23f35ec868d.

Required as STL change needs to be merged and gateway Java 17 update it's not ready yet