### PR TITLE
SRE-2245. Install node modules if there's no cache.

### DIFF
--- a/.github/workflows/build-reactjs.yaml
+++ b/.github/workflows/build-reactjs.yaml
@@ -104,8 +104,11 @@ jobs:
           echo "buildResultCached=${{ steps.cache-build-results.outputs.cache-hit }}" >> $GITHUB_OUTPUT
 
       - name: Install Yarn
-        if: steps.cache-build-results.outputs.cache-hit != 'true'
-        run: npm install -g yarn
+        if: steps.cache-build-results.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: |
+          set -eux
+          npm install -g yarn
+          yarn run yarn:install
 
       - name: Build license report
         if: steps.cache-build-results.outputs.cache-hit != 'true'


### PR DESCRIPTION
There is a bug in this action. If there's no cache for node_modules, the pipeline fails since there's no packages installed.
You can see failed actions https://github.com/hawk-ai-aml/frontend/actions/runs/5741163066.
Cache was deleted manually by one of engineers. After that the problem appeared.