### PR TITLE
ci: Step to run tests with SonarCloud in the build-java workflow.

### DIFF
--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -74,11 +74,13 @@ jobs:
     runs-on: [ "self-hosted", "builder" ]
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/checkout@v4
+      - name: Checkout master
+        uses: actions/checkout@v4
         with:
           ref: master
+
+      - name: Checkout current SHA
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -145,7 +145,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           ./gradlew check -isS
-          ./gradlew jacocoTestReport sonar         
+          ./gradlew jacocoTestReport sonar
 
       - name: License Report
         env:

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -74,7 +74,11 @@ jobs:
     runs-on: [ "self-hosted", "builder" ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          ref: master
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -29,6 +29,11 @@ on:
         type: boolean
         required: false
         default: false
+      useSonarCloud:
+        description: "Use SonarCloud for code quality checks"
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -49,6 +54,7 @@ jobs:
       ecr-registry-code: ${{ steps.init.outputs.ecr-registry-code }}
       ecr-region: ${{ steps.init.outputs.ecr-region }}
       metadata: ${{ steps.init.outputs.metadata }}
+      use-sonarcloud: ${{ steps.init.outputs.use-sonarcloud }}
 
     steps:
       - id: init
@@ -61,6 +67,7 @@ jobs:
           repository-name: hawk-ai-aml/${{ inputs.component }}
           repository-ref: ${{ env.GITHUB_REF_NAME }}
           repository-access-token: ${{ secrets.REPO_ACCESS_PAT }}
+          use-sonarcloud: ${{ inputs.useSonarCloud }}
 
   build:
     needs: [ init ]
@@ -106,7 +113,7 @@ jobs:
         run: ./gradlew checkQualityMain
 
       - name: Run Tests
-        if: ${{ needs.init.outputs.skip-tests != 'true' }}
+        if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud != 'true'}}
         env:
           ARTIFACTORY_CONTEXT_URL: ${{ secrets.ARTIFACTORY_CONTEXT_URL }}
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -116,6 +123,19 @@ jobs:
         run: |
           ./gradlew check -isS
           ./gradlew jacocoTestReport
+
+      - name: Run Tests With Sonar
+        if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud == 'true'}}
+        env:
+          ARTIFACTORY_CONTEXT_URL: ${{ secrets.ARTIFACTORY_CONTEXT_URL }}
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
+          GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          ./gradlew check -isS
+          ./gradlew jacocoTestReport sonar         
 
       - name: License Report
         env:

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - id: init
         name: Init Workflow
-        uses: hawk-ai-aml/github-actions/workflow-init@master
+        uses: hawk-ai-aml/github-actions/workflow-init@FRA-1574-quality-advanced-quality-analysis-with-sonar-cloud
         with:
           skip-tests: ${{ inputs.skipTests }}
           update-kustomize: ${{ inputs.updateKustomize }}

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -74,10 +74,15 @@ jobs:
     runs-on: [ "self-hosted", "builder" ]
 
     steps:
-      - name: Checkout current repository
+      - name: Checkout master
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: master
+
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GITHUB_REF_NAME }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -74,13 +74,10 @@ jobs:
     runs-on: [ "self-hosted", "builder" ]
 
     steps:
-      - name: Checkout master
+      - name: Checkout current repository
         uses: actions/checkout@v4
         with:
-          ref: master
-
-      - name: Checkout current SHA
-        uses: actions/checkout@v4
+          fetch-depth: 0
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -78,11 +78,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: master
+          fetch-depth: 1000
 
       - name: Checkout current branch
         uses: actions/checkout@v4
         with:
           ref: ${{ env.GITHUB_REF_NAME }}
+          fetch-depth: 1000
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - id: init
         name: Init Workflow
-        uses: hawk-ai-aml/github-actions/workflow-init@FRA-1574-quality-advanced-quality-analysis-with-sonar-cloud
+        uses: hawk-ai-aml/github-actions/workflow-init@master
         with:
           skip-tests: ${{ inputs.skipTests }}
           update-kustomize: ${{ inputs.updateKustomize }}

--- a/workflow-init/action.yml
+++ b/workflow-init/action.yml
@@ -86,10 +86,17 @@ runs:
       run: echo "HAWK_WORKFLOW_ID=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> ${GITHUB_ENV}
 
     - name: Checkout current repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository-name }}
         ref: ${{ inputs.repository-ref }}
+        token: ${{ inputs.repository-access-token }}
+
+    - name: Checkout current repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repository-name }}
+        ref: master
         token: ${{ inputs.repository-access-token }}
 
     - name: Load profile

--- a/workflow-init/action.yml
+++ b/workflow-init/action.yml
@@ -24,6 +24,10 @@ inputs:
   repository-access-token:
     description: "Access token to repository"
     required: true
+  use-sonarcloud:
+    description: "Hint to use SonarCloud"
+    required: false
+    default: "false"
 
 outputs:
   overlays:
@@ -69,6 +73,10 @@ outputs:
   metadata:
     description: 'The metadata of the current repository'
     value: ${{ steps.vars.outputs.metadata }}
+
+  use-sonarcloud:
+    description: 'Hint to use SonarCloud'
+    value: ${{ steps.vars.outputs.use-sonarcloud }}
 
 runs:
   using: composite
@@ -162,6 +170,8 @@ runs:
         fi
         
         OVERLAYS_STRING=$(echo ${OVERLAYS_JSON} | jq -r 'join(" ")')
+        
+        USE_SONARCLOUD=${{ inputs.use-sonarcloud }}
 
         # Workflow outputs
         cat <<EOF | tee -a ${GITHUB_STEP_SUMMARY} | tee -a ${GITHUB_OUTPUT}
@@ -176,6 +186,7 @@ runs:
         ecr-registry-code=${ECR_REGISTRY_CODE}
         ecr-region=${ECR_REGION}
         metadata=${METADATA}
+        use-sonarcloud=${USE_SONARCLOUD}
         EOF
 
         cat <<EOF | tee -a ${GITHUB_STEP_SUMMARY}

--- a/workflow-init/action.yml
+++ b/workflow-init/action.yml
@@ -92,7 +92,7 @@ runs:
         ref: ${{ inputs.repository-ref }}
         token: ${{ inputs.repository-access-token }}
 
-    - name: Checkout current repository
+    - name: Checkout current repository's master
       uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository-name }}

--- a/workflow-init/action.yml
+++ b/workflow-init/action.yml
@@ -92,13 +92,6 @@ runs:
         ref: ${{ inputs.repository-ref }}
         token: ${{ inputs.repository-access-token }}
 
-    - name: Checkout current repository's master
-      uses: actions/checkout@v4
-      with:
-        repository: ${{ inputs.repository-name }}
-        ref: master
-        token: ${{ inputs.repository-access-token }}
-
     - name: Load profile
       id: profile
       shell: bash -l -ET -eo pipefail {0}


### PR DESCRIPTION
## Description 
### Introduce SonarCloud check to the build java pipeline.

- Commit history of the PR branch is needed for Sonar. A shallow clone is not enough.
  - Fetching the latest 1000 commits for the PR branch to cover the history history

- Commit history of the Master branch is also needed for Sonar to have the diff between the master and PR branch.
  - Fetching the latest 1000 commit from the master to provide history.
  - Other branches and tags are not needed.

- In this iteration only to the `build-java`  workflow.

### Backward Compatibility 
- It is Backward compatible. No existing build will use it automatically. The `use-sonarcloud` param needs to be provided.
- if the `use-sonarcloud` input param is set to true it runs the test with sonar analysis otherwise runs without it as before. 


### The workflow is tested here: 
https://github.com/hawk-ai-aml/configuration/pull/443 