### PR TITLE
Feat(SRE-2996): added-error-message-for-failing-auto-tag-jq-operations

### DIFF
--- a/auto-tagging/action.yml
+++ b/auto-tagging/action.yml
@@ -25,9 +25,12 @@ runs:
             local repo=$1
             local number=$2
             local token=$3
-            curl -s -H "Authorization: token $token" \
-                -H "Accept: application/vnd.github.v3+json" \
-                "https://api.github.com/repos/$repo/issues/$number/labels" | jq -r '.[].name'
+
+            response=$(curl -s -H "Authorization: token $token" \
+                              -H "Accept: application/vnd.github.v3+json" \
+                              "https://api.github.com/repos/$repo/issues/$number/labels")
+
+            echo "$response" | jq -r '.[].name' || echo "Failed to parse JSON with jq. Response was: $response"
         }
 
         PR_LABELS=$(get_pr_labels "$GITHUB_REPOSITORY" "$PR_NUMBER" "$GITHUB_TOKEN")


### PR DESCRIPTION
At the moment, auto-tagging sometimes fails when the API request to retrieve the PR number for a specific github PR doesnt succeed. Its often a temporary issue but its not very clear what the api request error is. 

Often a retrigger of the workflow fixes the problem but we are not sure what the original cause of the failed api request is. This PR adds an error message for the request API.