### PR TITLE
SRE-3046 Clean up GH managed runner workspace.

### DIFF
--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -104,6 +104,15 @@ jobs:
           source_dir: ./report-dir
           destination_dir: ${{ github.event.repository.name }}-${{ github.run_id }}
 
+      - name: Clean up workspace
+        run: |
+          echo "Current virtual env size"
+          du -hcs $(pipenv --venv)
+          pipenv --clear
+          pipenv --rm
+          echo "Current disk usage:"
+          df -h /
+
       - name: Configure AWS credentials
         if: ${{ github.workflow != 'pr' }}
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
We need to clean up the workspace after tests. GH runners is limited in terms of disk space.
This is just a workaround.