### PR TITLE
Feat(OPX-1423): add slack notifications to builds

### DIFF
--- a/.github/workflows/build-scripts.yaml
+++ b/.github/workflows/build-scripts.yaml
@@ -6,16 +6,8 @@ on:
         description: "Update kustomize overlays (true/false)"
         type: boolean
         required: false
-      environment:
-        type: string
-        description: Environment
-        required: false
-      ref:
-        type: string
-        description: Tag or branch name
-        required: false
-      metadata:
-        description: The metadata for the test
+      kustomizeOverlays:
+        description: "Overlays to update"
         type: string
         required: false
       component:
@@ -48,6 +40,7 @@ jobs:
         name: Init Workflow
         uses: hawk-ai-aml/github-actions/workflow-init@master
         with:
+          overlays: ${{ inputs.kustomizeOverlays }}
           update-kustomize: ${{ inputs.updateKustomize }}
           repository-name: hawk-ai-aml/${{ inputs.component }}
           repository-ref: ${{ env.GITHUB_REF_NAME }}
@@ -62,6 +55,15 @@ jobs:
           repository-user: ${{ secrets.RECREATE_DEVELOP_GITHUB_USER }}
           repository-access-token: ${{ secrets.REPO_ACCESS_PAT }}
           modules-string: ${{ steps.init.outputs.kustomize-modules-string }}
+
+      - name: Slack notification for failed init workflow
+        uses: hawk-ai-aml/github-actions/send-slack-notification@master
+        if: failure()
+        with:
+          notify-pr-author: true
+          slack-message: ":x: The init workflow failed. Please check the reason for it and contact @team-pe."
+          slack-access-token: ${{ secrets.SLACK_RELEASE_BOT_ACCESS_TOKEN }}
+          github-users-access-token: ${{ secrets.USER_GITHUB_ACCESS }} 
 
   build:
     needs: [ init ]
@@ -104,6 +106,15 @@ jobs:
         run: |
           docker push ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
 
+      - name: Slack notification for failed overlay update workflow
+        uses: hawk-ai-aml/github-actions/send-slack-notification@master
+        if: failure()
+        with:
+          notify-pr-author: true
+          slack-message: ":x: Your build failed. Please check the reason for it."
+          slack-access-token: ${{ secrets.SLACK_RELEASE_BOT_ACCESS_TOKEN }}
+          github-users-access-token: ${{ secrets.USER_GITHUB_ACCESS }} 
+
   update-overlays:
     needs: [ init, build ]
     if: ${{ needs.init.outputs.update-kustomize == 'true' && github.workflow != 'pr' }}
@@ -122,3 +133,21 @@ jobs:
           ecr-region: ${{ needs.init.outputs.ecr-region }}
           ecr-registry-code: ${{ needs.init.outputs.ecr-registry-code }}
           metadata: ${{ needs.init.outputs.metadata }}
+
+      - name: Slack notification for successful overlay update workflow
+        uses: hawk-ai-aml/github-actions/send-slack-notification@master
+        if: success()
+        with:
+          notify-pr-author: true
+          slack-message: ":tada: Successfully updated overlay ${{ needs.init.outputs.overlays }} with ${{ inputs.component }}:${{ needs.init.outputs.image-tag }}."
+          slack-access-token: ${{ secrets.SLACK_RELEASE_BOT_ACCESS_TOKEN }}
+          github-users-access-token: ${{ secrets.USER_GITHUB_ACCESS }}    
+
+      - name: Slack notification for failed overlay update workflow
+        uses: hawk-ai-aml/github-actions/send-slack-notification@master
+        if: failure()
+        with:
+          notify-pr-author: true
+          slack-message: ":x: The update overlay workflow failed. Please check the reason for it and contact @team-pe."
+          slack-access-token: ${{ secrets.SLACK_RELEASE_BOT_ACCESS_TOKEN }}
+          github-users-access-token: ${{ secrets.USER_GITHUB_ACCESS }}       

--- a/send-slack-notification/README.md
+++ b/send-slack-notification/README.md
@@ -1,0 +1,30 @@
+# Send Slack Notifications
+
+It is able to notify both the author of the PR as well as a slack channel. For the slack channel, there is a mapping json file that needs to be adjusted for new slack channel because of their ID. Each slack notification can have their own slack message attached to it.
+
+# How to use the slack notification within github actions
+Usage
+```
+  slack-notification:
+    if: always()
+    runs-on: [ "self-hosted", "small-builder" ]
+
+    steps:
+      - name: Send slack notification to PR author
+        uses: hawk-ai-aml/github-actions/send-slack-notification@master
+        with:
+          notify-pr-author: true
+          notify-slack-channel-name: developers
+          slack-message: "Write your message here"
+          slack-access-token: ${{ secrets.SLACK_RELEASE_BOT_ACCESS_TOKEN }}
+          github-users-access-token: ${{ secrets.USER_GITHUB_ACCESS }}
+
+```
+
+can be found in: .github/workflows/build-scripts.yaml
+
+# How to add a new slack channel
+
+1. You have to get the slack channel id
+2. Map the name of the channel to its id in the slack_channel_mapping.json file
+3. Go to your slack channel and add the release bot as an integration app to the channel. (can be done directly within Slack by anyone)

--- a/send-slack-notification/action.yml
+++ b/send-slack-notification/action.yml
@@ -1,0 +1,107 @@
+name: send-slack-notification
+description: Send a direct slack notification to authors or slack channels
+
+inputs:
+  notify-pr-author:
+    description: "Boolean value indicating if the slack notification should be sent to the author only"
+    required: true
+  slack-message:
+    description: "The message to send to the Slack channel"
+    required: true
+  slack-access-token:
+    description: "Access token to slack"
+    required: true
+  github-users-access-token:
+    description: "Access token to GitHub users"
+    required: true
+  notify-slack-channel-name:
+    default: ""
+    description: "The Slack channel name to send the notification to. There is a mapping of slack names to ID."
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout Kustomize
+      uses: actions/checkout@v4
+      with:
+        repository: hawk-ai-aml/github-actions.git
+        ref: master
+
+    - shell: bash -l -ET -eo pipefail {0}
+      name: Send DM Slack notification when pipeline fails
+      env:
+        INPUT_NOTIFY_PR_AUTHOR: ${{ inputs.notify-pr-author }}
+        INPUT_SLACK_MESSAGE: ${{ inputs.slack-message }}
+        INPUT_NOTIFY_SLACK_CHANNEL_NAME: ${{ inputs.notify-slack-channel-name }}
+        SLACK_TOKEN: ${{ inputs.slack-access-token }}
+        GITHUB_USER_ACCESS: ${{ inputs.github-users-access-token }}
+        SLACK_CHANNEL_MAPPING_FILE: send-slack-notification/slack_channel_mapping.json
+      run: |
+
+        GITHUB_ACTOR=${{ github.actor }}
+        REPO=${{ github.repository }}
+        RUN_ID=${{ github.run_id }}
+
+        # Construct the URL for the current GitHub Action run
+        RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
+        # Retrieve the repository and run ID
+        REPO="${{ github.repository }}"
+        BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+        
+        # Fetch GitHub user profile; extract blog URL; remove double quotes
+        SLACK_USER_ID=$(curl -s -H "Authorization: token $GITHUB_USER_ACCESS" "https://api.github.com/users/$GITHUB_ACTOR" | jq '.blog' | sed 's/"//g')
+
+        slack_text="[$REPO]\n\n$INPUT_SLACK_MESSAGE \n\n> branch-name: $BRANCH_NAME\n> <$RUN_URL|Github Link>\n\n"
+        found_slack_id=true
+
+        if [[ "$INPUT_NOTIFY_PR_AUTHOR" == "true" ]]; then
+          if [[ -n "$SLACK_USER_ID" && "$SLACK_USER_ID" != "null" && "$INPUT_NOTIFY_PR_AUTHOR" == "true" ]]; then
+
+            # Send message to the user's Slack channel
+            SLACK_RESPONSE=$(curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json' \
+            --data "{\"channel\":\"$SLACK_USER_ID\",\"text\":\"$slack_text\"}" \
+            https://slack.com/api/chat.postMessage)
+
+            # Print the Slack response (optional for debugging purposes)
+            echo $SLACK_RESPONSE
+
+            # Check if the response contains "ok": false
+            if echo $SLACK_RESPONSE | grep -q '"ok":false'; then
+              echo "Failed to send Slack notification to $GITHUB_ACTOR."
+              exit 1
+            else
+              echo "Slack notification sent successfully to $GITHUB_ACTOR."
+            fi
+          else
+            INPUT_NOTIFY_SLACK_CHANNEL_NAME="developers"
+            found_slack_id=false
+          fi
+        fi
+
+        if [[ "$INPUT_NOTIFY_SLACK_CHANNEL_NAME" != ""  ]]; then
+          if [[ "$found_slack_id" == "false" ]]; then
+            echo "Slack user ID not found for GitHub user: $GITHUB_ACTOR"
+            slack_text+="\n\n---------------\n\nThere is no slack_id found in the profile. @$GITHUB_ACTOR please add it -> https://hawkai.atlassian.net/wiki/spaces/SRE/pages/3408363526/GitHub+Onboarding+Guide#4.-Personalize-your-profile"
+          fi
+
+          # Extract the channel ID from the JSON file using jq
+          SLACK_CHANNEL_ID=$(jq -r --arg channel_name "$INPUT_NOTIFY_SLACK_CHANNEL_NAME" '.[$channel_name]' "$SLACK_CHANNEL_MAPPING_FILE")
+
+          # Send the message using curl
+          SLACK_RESPONSE=$(curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json' \
+              --data "{\"channel\":\"$SLACK_CHANNEL_ID\",\"text\":\"$slack_text\"}" \
+              https://slack.com/api/chat.postMessage)
+
+          # Print the Slack response (optional for debugging purposes)
+          echo $SLACK_RESPONSE
+
+          if echo $SLACK_RESPONSE | grep -q '"ok":false'; then
+            echo "Failed to send Slack notification to $INPUT_NOTIFY_SLACK_CHANNEL_NAME channel."
+            exit 1
+          else
+            echo "Slack notification sent successfully to $INPUT_NOTIFY_SLACK_CHANNEL_NAME channel."
+          fi
+
+          exit 0
+        fi

--- a/send-slack-notification/slack_channel_mapping.json
+++ b/send-slack-notification/slack_channel_mapping.json
@@ -1,0 +1,6 @@
+{
+    "developers": "C014BJSF279",
+    "releasing": "C01HJV7K8QL",
+    "slack-webhook-tests": "C04TY9PB1HT",
+    "terraform-cicd": "C04LG612CGJ"
+}


### PR DESCRIPTION
### Implement Slack Notification github action module

I would like to introduce a new module to add slack notifications to existing github workflow modules. 

I have added two kinds of notifications: failing and successful.
![image](https://github.com/hawk-ai-aml/github-actions/assets/105926661/daf7d272-662e-436f-b810-1bcd823fc9b8)

Success:
- triggered when overlay was updated

Failure:
- triggered when overlay update failed
- build failed

Example: 

        uses: hawk-ai-aml/github-actions/send-slack-notification@master
        with:
          notify-pr-author: true
          notify-slack-channel-name: developers
          slack-message: "Write your message here"
          slack-access-token: ${{ secrets.SLACK_RELEASE_BOT_ACCESS_TOKEN }}
          github-users-access-token: ${{ secrets.USER_GITHUB_ACCESS }}

It is able to notify both the author of the PR as well as a slack channel. For the slack channel, there is a mapping json file that needs to be adjusted for new slack channel because of their ID.
Each slack notification can have their own slack message attached to it.

### Risk Assessment
impact:1 * likelyhood:1 = risk:1

### Story Link
https://hawkai.atlassian.net/browse/OPX-1423

### Checklist
- [x] Verify your changes on dev if needed.
