### PR TITLE
feat(FRA-2215): Add sonar scan step to python build

### DIFF
--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -73,7 +73,7 @@ jobs:
         with:
           # From SonarCloud Scan GitHub Action
           # Disabling shallow clone is recommended for improving relevancy of reporting
-          fetch-depth: 0
+          fetch-depth: 30
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -114,6 +114,9 @@ jobs:
       - name: SonarCloud Scan
         if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud == 'true'}}
         uses: SonarSource/sonarcloud-github-action@master
+        with:
+          args: >
+            -Dsonar.python.version=${{ fromJson(needs.init.outputs.metadata).python-version }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -70,6 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # From SonarCloud Scan GitHub Action
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -73,7 +73,7 @@ jobs:
         with:
           # From SonarCloud Scan GitHub Action
           # Disabling shallow clone is recommended for improving relevancy of reporting
-          fetch-depth: 50
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -25,6 +25,11 @@ on:
         type: boolean
         required: false
         default: false
+      useSonarCloud:
+        description: "Use SonarCloud for code quality checks"
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -45,6 +50,7 @@ jobs:
       ecr-registry-code: ${{ steps.init.outputs.ecr-registry-code }}
       ecr-region: ${{ steps.init.outputs.ecr-region }}
       metadata: ${{ steps.init.outputs.metadata }}
+      use-sonarcloud: ${{ steps.init.outputs.use-sonarcloud }}
 
     steps:
       - id: init
@@ -57,6 +63,7 @@ jobs:
           repository-name: hawk-ai-aml/${{ inputs.component }}
           repository-ref: ${{ env.GITHUB_REF_NAME }}
           repository-access-token: ${{ secrets.REPO_ACCESS_PAT }}
+          use-sonarcloud: ${{ inputs.useSonarCloud }}
 
   build:
     needs: init
@@ -103,6 +110,13 @@ jobs:
           aws_bucket: github-actions-static-html-2
           source_dir: ./report-dir
           destination_dir: ${{ github.event.repository.name }}-${{ github.run_id }}
+
+      - name: SonarCloud Scan
+        if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud == 'true'}}
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       - name: Clean up workspace
         run: |

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -73,7 +73,7 @@ jobs:
         with:
           # From SonarCloud Scan GitHub Action
           # Disabling shallow clone is recommended for improving relevancy of reporting
-          fetch-depth: 0
+          fetch-depth: 50
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Added a step to python build for sonar cloud scan.

- Sonar's Github Action is used
- Fetch depth is set to 30 to fetch the last 30 commits. Sonar suggests 0 (all commits) but that might slow us down.