### PR TITLE
build(FRA-2253) Fetch status check from Sonar and block build if it fails

### DIFF
--- a/.github/workflows/build-java-multi.yaml
+++ b/.github/workflows/build-java-multi.yaml
@@ -279,7 +279,8 @@ jobs:
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
         run: |
           RESPONSE=$(curl -s -H 'Authorization: Bearer ${{ env.SONAR_TOKEN }}' ${{ env.SONAR_HOST_URL }}/api/qualitygates/project_status?projectKey=hawk-ai_${{ matrix.module }}&pullRequest=${{ env.PR_NUMBER }})
-          STATUS=$(echo $RESPONSE | jq -r '.projectStatus.status')
+          STATUS=${{fromJson(${{RESPONSE}}).projectStatus.status}}
+          echo "Sonar Status: $STATUS"
           
           # Check if the status is "OK"
           if [ "$STATUS" == "OK" ]; then

--- a/.github/workflows/build-java-multi.yaml
+++ b/.github/workflows/build-java-multi.yaml
@@ -283,11 +283,7 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
         run: |
-          SONAR_PROJECT_KEY=$(grep -oP '(?<=property "sonar.projectKey", ")[^"]*' ${{ matrix.module }}/build.gradle)
-          echo "Sonar Project Key: $SONAR_PROJECT_KEY"
-          REPOSITORY_NAME=${{ github.event.repository.name }}
-          MODULE=${{matrix.module}}
-          PROJECT_KEY=${{env.SONAR_ORGANIZATION}}_${REPOSITORY_NAME}-${MODULE}
+          PROJECT_KEY=$(grep -oP '(?<=property "sonar.projectKey", ")[^"]*' ${{ matrix.module }}/build.gradle)
           RESPONSE=$(curl -s -H 'Authorization: Bearer ${{env.SONAR_TOKEN}}' ${{env.SONAR_HOST_URL}}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}\&pullRequest=${{env.PR_NUMBER}})
           STATUS=$(echo $RESPONSE | jq -r '.projectStatus.status')
           echo "SonarQuality Status: $STATUS"

--- a/.github/workflows/build-java-multi.yaml
+++ b/.github/workflows/build-java-multi.yaml
@@ -279,7 +279,7 @@ jobs:
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
         run: |
           RESPONSE=$(curl -s -H 'Authorization: Bearer ${{ env.SONAR_TOKEN }}' ${{ env.SONAR_HOST_URL }}/api/qualitygates/project_status?projectKey=hawk-ai_${{ matrix.module }}&pullRequest=${{ env.PR_NUMBER }})
-          STATUS=${{fromJson(${{RESPONSE}}).projectStatus.status}}
+          STATUS=$(echo $RESPONSE | jq -r '.projectStatus.status')
           echo "Sonar Status: $STATUS"
           
           # Check if the status is "OK"

--- a/.github/workflows/build-java-multi.yaml
+++ b/.github/workflows/build-java-multi.yaml
@@ -274,7 +274,6 @@ jobs:
         if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud == 'true'}}
         env:
           PR_NUMBER: ${{ github.event.number }}
-          CI_BUILD: true
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}

--- a/.github/workflows/build-java-multi.yaml
+++ b/.github/workflows/build-java-multi.yaml
@@ -269,7 +269,8 @@ jobs:
           ./gradlew :${{ matrix.module }}:jib \
             -DIMAGE_NAME="${ECR_REGISTRY}/${ECR_REPOSITORY_PREFIX}" \
             -DTAG_COMMIT=${IMAGE_TAG}
-      - name: Check Sonar Report passed
+
+      - name: Check SonarCloud Code Analysis passed
         if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud == 'true'}}
         env:
           PR_NUMBER: ${{ github.event.number }}
@@ -278,17 +279,19 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
         run: |
-          RESPONSE=$(curl -s -H 'Authorization: Bearer ${{ env.SONAR_TOKEN }}' ${{ env.SONAR_HOST_URL }}/api/qualitygates/project_status?projectKey=hawk-ai_${{ matrix.module }}&pullRequest=${{ env.PR_NUMBER }})
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          MODULE=${{matrix.module}}
+          PROJECT_KEY=${{env.SONAR_ORGANIZATION}}_${REPOSITORY_NAME}-${MODULE}
+          RESPONSE=$(curl -s -H 'Authorization: Bearer ${{env.SONAR_TOKEN}}' ${{env.SONAR_HOST_URL}}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}\&pullRequest=${{env.PR_NUMBER}})
           STATUS=$(echo $RESPONSE | jq -r '.projectStatus.status')
-          echo "Sonar Status: $STATUS"
+          echo "SonarQuality Status: $STATUS"
           
           # Check if the status is "OK"
           if [ "$STATUS" == "OK" ]; then
-            exit 1
-          else
             exit 0
+          else
+            exit 1
           fi
-          
 
   check-if-all-builds-passed:
     if: always()

--- a/.github/workflows/build-java-multi.yaml
+++ b/.github/workflows/build-java-multi.yaml
@@ -62,7 +62,6 @@ jobs:
       updated-modules: ${{ steps.detect-changes.outputs.updated-modules }}
       updated-modules-string: ${{ steps.detect-changes.outputs.updated-modules-string }}
       use-sonarcloud: ${{ steps.init.outputs.use-sonarcloud }}
-      block-pull-request-if-sonar-fails: ${{ steps.init.outputs.block-pull-request-if-sonar-fails }}
 
     steps:
       - id: init
@@ -76,7 +75,6 @@ jobs:
           repository-ref: ${{ env.GITHUB_REF_NAME }}
           repository-access-token: ${{ secrets.REPO_ACCESS_PAT }}
           use-sonarcloud: ${{ inputs.useSonarCloud }}
-          block-pull-request-if-sonar-fails: ${{ inputs.blockPullRequestIfSonarFails }}
 
       - id: detect-changes
         name: Detect changes
@@ -278,7 +276,7 @@ jobs:
             -DTAG_COMMIT=${IMAGE_TAG}
 
       - name: Check SonarCloud Code Analysis passed
-        if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud == 'true' && needs.init.outputs.block-pull-request-if-sonar-fails == 'true'}}
+        if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud == 'true' && inputs.blockPullRequestIfSonarFails == true }}
         env:
           PR_NUMBER: ${{ github.event.number }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build-java-multi.yaml
+++ b/.github/workflows/build-java-multi.yaml
@@ -269,6 +269,25 @@ jobs:
           ./gradlew :${{ matrix.module }}:jib \
             -DIMAGE_NAME="${ECR_REGISTRY}/${ECR_REPOSITORY_PREFIX}" \
             -DTAG_COMMIT=${IMAGE_TAG}
+      - name: Check Sonar Report passed
+        if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud == 'true'}}
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          CI_BUILD: true
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+        run: |
+          RESPONSE=$(curl -s -H 'Authorization: Bearer ${{ env.SONAR_TOKEN }}' ${{ env.SONAR_HOST_URL }}/api/qualitygates/project_status?projectKey=hawk-ai_${{ matrix.module }}&pullRequest=${{ env.PR_NUMBER }})
+          STATUS=$(echo $RESPONSE | jq -r '.projectStatus.status')
+          
+          # Check if the status is "OK"
+          if [ "$STATUS" == "OK" ]; then
+            exit 1
+          else
+            exit 0
+          fi
+          
 
   check-if-all-builds-passed:
     if: always()

--- a/.github/workflows/build-java-multi.yaml
+++ b/.github/workflows/build-java-multi.yaml
@@ -283,6 +283,8 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
         run: |
+          SONAR_PROJECT_KEY=$(grep -oP '(?<=property "sonar.projectKey", ")[^"]*' ${{ matrix.module }}/build.gradle)
+          echo "Sonar Project Key: $SONAR_PROJECT_KEY"
           REPOSITORY_NAME=${{ github.event.repository.name }}
           MODULE=${{matrix.module}}
           PROJECT_KEY=${{env.SONAR_ORGANIZATION}}_${REPOSITORY_NAME}-${MODULE}

--- a/.github/workflows/build-java-multi.yaml
+++ b/.github/workflows/build-java-multi.yaml
@@ -30,6 +30,11 @@ on:
         type: boolean
         required: false
         default: false
+      blockPullRequestIfSonarFails:
+        description: "Block the pull request if SonarCloud check fails"
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -57,6 +62,7 @@ jobs:
       updated-modules: ${{ steps.detect-changes.outputs.updated-modules }}
       updated-modules-string: ${{ steps.detect-changes.outputs.updated-modules-string }}
       use-sonarcloud: ${{ steps.init.outputs.use-sonarcloud }}
+      block-pull-request-if-sonar-fails: ${{ steps.init.outputs.block-pull-request-if-sonar-fails }}
 
     steps:
       - id: init
@@ -70,6 +76,7 @@ jobs:
           repository-ref: ${{ env.GITHUB_REF_NAME }}
           repository-access-token: ${{ secrets.REPO_ACCESS_PAT }}
           use-sonarcloud: ${{ inputs.useSonarCloud }}
+          block-pull-request-if-sonar-fails: ${{ inputs.blockPullRequestIfSonarFails }}
 
       - id: detect-changes
         name: Detect changes
@@ -271,7 +278,7 @@ jobs:
             -DTAG_COMMIT=${IMAGE_TAG}
 
       - name: Check SonarCloud Code Analysis passed
-        if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud == 'true'}}
+        if: ${{ needs.init.outputs.skip-tests != 'true' && needs.init.outputs.use-sonarcloud == 'true' && needs.init.outputs.block-pull-request-if-sonar-fails == 'true'}}
         env:
           PR_NUMBER: ${{ github.event.number }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build-python-multi.yaml
+++ b/.github/workflows/build-python-multi.yaml
@@ -229,7 +229,7 @@ jobs:
         run: |
           REPOSITORY_NAME=${{ github.event.repository.name }}
           MODULE=${{matrix.module}}
-          PROJECT_KEY=${{env.SONAR_ORGANIZATION}}_${REPOSITORY_NAME}-${MODULE}
+          PROJECT_KEY=${{env.SONAR_ORGANIZATION}}_${MODULE//_/-}
           RESPONSE=$(curl -s -H 'Authorization: Bearer ${{env.SONAR_TOKEN}}' ${{env.SONAR_HOST_URL}}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}\&pullRequest=${{env.PR_NUMBER}})
           STATUS=$(echo $RESPONSE | jq -r '.projectStatus.status')
           echo "SonarQuality Status: $STATUS"

--- a/.github/workflows/build-python-multi.yaml
+++ b/.github/workflows/build-python-multi.yaml
@@ -232,9 +232,7 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
         run: |
-          REPOSITORY_NAME=${{ github.event.repository.name }}
-          MODULE=${{matrix.module}}
-          PROJECT_KEY=${{env.SONAR_ORGANIZATION}}_${REPOSITORY_NAME}_${MODULE}
+          PROJECT_KEY=$(grep '^sonar.projectKey=' sonar-project.properties | cut -d '=' -f 2)
           RESPONSE=$(curl -s -H 'Authorization: Bearer ${{env.SONAR_TOKEN}}' ${{env.SONAR_HOST_URL}}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}\&pullRequest=${{env.PR_NUMBER}})
           STATUS=$(echo $RESPONSE | jq -r '.projectStatus.status')
           echo "SonarQuality Status: $STATUS"

--- a/.github/workflows/build-python-multi.yaml
+++ b/.github/workflows/build-python-multi.yaml
@@ -36,6 +36,11 @@ on:
         type: boolean
         required: false
         default: false
+      blockPullRequestIfSonarFails:
+        description: "Block the pull request if SonarCloud check fails"
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   init:
@@ -220,7 +225,7 @@ jobs:
           docker push ${REPOSITORY_FULL_NAME}:${IMAGE_TAG}
 
       - name: Check SonarCloud Code Analysis passed
-        if: inputs.skipTests != true && (success() || failure()) && inputs.useSonarCloud
+        if: inputs.skipTests != true && (success() || failure()) && inputs.useSonarCloud && inputs.blockPullRequestIfSonarFails
         env:
           PR_NUMBER: ${{ github.event.number }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -229,7 +234,7 @@ jobs:
         run: |
           REPOSITORY_NAME=${{ github.event.repository.name }}
           MODULE=${{matrix.module}}
-          PROJECT_KEY=${{env.SONAR_ORGANIZATION}}_${MODULE//_/-}
+          PROJECT_KEY=${{env.SONAR_ORGANIZATION}}_${REPOSITORY_NAME}_${MODULE}
           RESPONSE=$(curl -s -H 'Authorization: Bearer ${{env.SONAR_TOKEN}}' ${{env.SONAR_HOST_URL}}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}\&pullRequest=${{env.PR_NUMBER}})
           STATUS=$(echo $RESPONSE | jq -r '.projectStatus.status')
           echo "SonarQuality Status: $STATUS"

--- a/.github/workflows/build-python-multi.yaml
+++ b/.github/workflows/build-python-multi.yaml
@@ -219,6 +219,28 @@ jobs:
           DOCKER_BUILDKIT=1 docker build --build-arg SERVICE=${MODULE} --build-arg PY_UTILS_PAT=${PY_UTILS_PAT} -t ${REPOSITORY_FULL_NAME}:${IMAGE_TAG} .
           docker push ${REPOSITORY_FULL_NAME}:${IMAGE_TAG}
 
+      - name: Check SonarCloud Code Analysis passed
+        if: inputs.skipTests != true && (success() || failure()) && inputs.useSonarCloud
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+        run: |
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          MODULE=${{matrix.module}}
+          PROJECT_KEY=${{env.SONAR_ORGANIZATION}}_${REPOSITORY_NAME}-${MODULE}
+          RESPONSE=$(curl -s -H 'Authorization: Bearer ${{env.SONAR_TOKEN}}' ${{env.SONAR_HOST_URL}}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}\&pullRequest=${{env.PR_NUMBER}})
+          STATUS=$(echo $RESPONSE | jq -r '.projectStatus.status')
+          echo "SonarQuality Status: $STATUS"
+          
+          # Check if the status is "OK"
+          if [ "$STATUS" == "OK" ]; then
+            exit 0
+          else
+            exit 1
+          fi
+
   check-if-all-builds-passed:
     if: always()
     needs: [ build ]


### PR DESCRIPTION
Add an additional step to verify the Sonar check. 
To verify that it's passed: 
- send request to SonarCloud (include `projectKey` and `pullRequest` to fetch status about exactly this PR) 
- check `projectStatus.status` from the response. It's an overall status of the check, so if at least 1 check hasn't passed, the result will be not "OK" (either "FAILED", or some other options, doesn't matter for us) 
- return `0` from the step if the response if OK, `1` otherwise 

Additionally I introduced a parameter `blockPullRequestIfSonarFails`. If the parameter is `false` (by default), then don't run this step. In this case we can add this parameter to repositories separately and make sure that it works for each of them.

Example PR where the step was tested: https://github.com/hawk-ai-aml/backend/pull/1345

The `archiver` module was broken on purpose to see that SonarCloud check fails, and the build of the module fails as well. For `core` module which was also modified, SonarCloud check is green, and the build is green as well