### PR TITLE
ERS-1958 add reusable workflow for multi-Python with Poetry

### DIFF
--- a/.github/workflows/build-python-poetry-multi.yaml
+++ b/.github/workflows/build-python-poetry-multi.yaml
@@ -1,0 +1,322 @@
+name: build
+
+on:
+  workflow_call:
+    inputs:
+      updateKustomize:
+        description: "Update kustomize overlays"
+        type: boolean
+        required: false
+      skipTests:
+        description: "Skip extended testing (unit and other tests), only build artifacts"
+        type: boolean
+        required: false
+        default: false
+      kustomizeOverlays:
+        description: "The indicated overlays (dev, test, qa, prod)"
+        type: string
+        required: false
+      ecr-prefix:
+        type: string
+        required: false
+      caller-workflow-type:
+        type: string
+        required: true
+      component:
+        description: "Name of the repository"
+        type: string
+        required: false
+      vulnerabilityCheck:
+        description: "Conduct a vulnerability check using Lacework"
+        type: boolean
+        required: false
+        default: false
+      useSonarCloud:
+        description: "Use SonarCloud for code quality checks"
+        type: boolean
+        required: false
+        default: false
+      blockPullRequestIfSonarFails:
+        description: "Block the pull request if SonarCloud check fails"
+        type: boolean
+        required: false
+        default: false
+
+env:
+  POETRY_VERSION: 1.8.4
+
+defaults:
+  run:
+    shell: bash -l -ET -eo pipefail {0}
+
+jobs:
+  init:
+    runs-on: [ "self-hosted", "small-builder" ]
+    outputs:
+      overlays: ${{ steps.init.outputs.overlays }}
+      update-kustomize: ${{ steps.init.outputs.update-kustomize }}
+      skip-tests: ${{ steps.init.outputs.skip-tests }}
+      image-tag: ${{ steps.init.outputs.image-tag }}
+      ecr-url: ${{ steps.init.outputs.ecr-url }}
+      kustomize-modules: ${{ steps.init.outputs.kustomize-modules }}
+      kustomize-modules-string: ${{ steps.init.outputs.kustomize-modules-string }}
+      ecr-images: ${{ steps.init.outputs.ecr-images }}
+      ecr-registry-code: ${{ steps.init.outputs.ecr-registry-code }}
+      ecr-region: ${{ steps.init.outputs.ecr-region }}
+      metadata: ${{ steps.init.outputs.metadata }}
+      updated-modules: ${{ steps.detect-changes.outputs.updated-modules }}
+      updated-modules-string: ${{ steps.detect-changes.outputs.updated-modules-string }}
+
+    steps:
+      - id: init
+        name: Init workflow
+        uses: hawk-ai-aml/github-actions/workflow-init@master
+        with:
+          skip-tests: ${{ inputs.skipTests }}
+          update-kustomize: ${{ inputs.updateKustomize }}
+          overlays: ${{ inputs.kustomizeOverlays }}
+          repository-name: hawk-ai-aml/${{ inputs.component }}
+          repository-ref: ${{ env.GITHUB_REF_NAME }}
+          repository-access-token: ${{ secrets.REPO_ACCESS_PAT }}
+
+      - id: detect-changes
+        name: Detect changes
+        uses: hawk-ai-aml/github-actions/repository-detect-changes@master
+        with:
+          repository: hawk-ai-aml/${{ inputs.component }}
+          repository-ref: ${{ env.GITHUB_REF_NAME }}
+          repository-user: ${{ secrets.RECREATE_DEVELOP_GITHUB_USER }}
+          repository-access-token: ${{ secrets.REPO_ACCESS_PAT }}
+          modules-string: ${{ steps.init.outputs.kustomize-modules-string }}
+
+  build:
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJson(needs.init.outputs.updated-modules) }}
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          # From SonarCloud Scan GitHub Action
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 1000
+
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GITHUB_REF_NAME }}
+          # From SonarCloud Scan GitHub Action
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 1000
+
+      - name: Install Poetry
+        run: pipx install "poetry==${{ env.POETRY_VERSION }}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ fromJson(needs.init.outputs.metadata).python-version }}
+          cache: poetry
+
+      - name: Authorize to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CLOUD_STORAGE_SERVICE_ACCOUNT_KEY }}
+
+      - name: Authorize Poetry
+        run: scripts/authorize_poetry.sh
+        env:
+          PY_UTILS_PAT: ${{ secrets.PY_UTILS_PAT }}
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run tests for module
+        if: inputs.skipTests != true && (success() || failure())
+        env:
+          JENKINS: true
+          IS_JENKINS: true
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DEV_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DEV_SECRET_ACCESS_KEY }}
+        run: |
+          poetry run pytest \
+            --cov=${{ matrix.module }} \
+            --junitxml=${{ matrix.module }}/report.xml \
+            tests/${{ matrix.module }}
+
+      - name: Generate reports for module
+        if: inputs.skipTests != true && (success() || failure())
+        working-directory: ${{ matrix.module }}
+        run: |
+          poetry run junit2html report.xml report.html
+          mkdir report-dir && mv report.html ./report-dir/report.html
+
+      - name: Upload reports to S3 for module
+        if: inputs.skipTests != true && (success() || failure())
+        uses: hawk-ai-aml/github-actions/upload-to-s3@master
+        with:
+          module: ${{ matrix.module }}
+          aws_access_key_id: ${{ secrets.AWS_DEV_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_DEV_SECRET_ACCESS_KEY }}
+          aws_bucket: github-actions-static-html-2
+          source_dir: ${{ matrix.module }}/report-dir
+          destination_dir: ${{ github.event.repository.name }}-${{ matrix.module }}-${{ github.run_id }}
+
+      - name: SonarCloud scan
+        if: inputs.skipTests != true && (success() || failure()) && inputs.useSonarCloud
+        uses: SonarSource/sonarcloud-github-action@master
+        with:
+          args: >
+            -Dsonar.python.version=${{ fromJson(needs.init.outputs.metadata).python-version }}
+          projectBaseDir: ${{ matrix.module }}/
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+      - name: Get ECR info
+        id: ecr-info
+        env:
+          METADATA: ${{ needs.init.outputs.metadata }}
+        run: |
+          MODULE_ECR=$(echo ${METADATA} | jq -cr --arg MODULE ${{ matrix.module }} '.modules[$MODULE].ecr')
+          echo "ECR=$MODULE_ECR"
+          echo "module_ecr=$MODULE_ECR" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS credentials
+        if: ${{ github.workflow != 'pr' && steps.ecr-info.outputs.module_ecr != 'null' }}
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ORG_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ORG_ECR_SECRET_ACCESS_KEY }}
+          aws-region: ${{ needs.init.outputs.ecr-region }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        if: ${{ github.workflow != 'pr' && steps.ecr-info.outputs.module_ecr != 'null' }}
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registries: ${{ needs.init.outputs.ecr-registry-code }}
+
+      - name: Check if Docker image tag exists in ECR
+        id: check-tag
+        if: ${{ github.workflow != 'pr' && steps.ecr-info.outputs.module_ecr != 'null' }}
+        uses: hawk-ai-aml/github-actions/check-docker-tag-exists@master
+        with:
+          ecr-registry: ${{ steps.login-ecr.outputs.registry }}
+          ecr-repository: ${{ steps.ecr-info.outputs.module_ecr }}
+          image-tag: ${{ needs.init.outputs.image-tag }}
+
+      - name: Build and tag images
+        if: ${{ github.workflow != 'pr' && steps.ecr-info.outputs.module_ecr != 'null' && steps.check-tag.outputs.tag_already_exists != 'true' }}
+        env:
+          IMAGE_TAG: ${{ needs.init.outputs.image-tag }}
+          ECR_PREFIX: ${{ inputs.ecr-prefix }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          PY_UTILS_PAT: ${{ secrets.PY_UTILS_PAT }}
+          MODULE: ${{ matrix.module }}
+        run: |
+          REPOSITORY_FOLDER=$(echo ${MODULE} | sed 's/\_/\-/g')
+          REPOSITORY_FULL_NAME="${ECR_REGISTRY}/${ECR_PREFIX}${REPOSITORY_FOLDER}"
+
+          echo "${REPOSITORY_FULL_NAME} is building..."
+
+          DOCKER_BUILDKIT=1 docker build \
+            --build-arg SERVICE=${MODULE} \
+            --build-arg PY_UTILS_PAT=${PY_UTILS_PAT} \
+            -t ${REPOSITORY_FULL_NAME}:${IMAGE_TAG} \
+            .
+
+          docker push ${REPOSITORY_FULL_NAME}:${IMAGE_TAG}
+
+      - name: Check if SonarCloud code analysis has passed
+        if: inputs.skipTests != true && (success() || failure()) && inputs.useSonarCloud && inputs.blockPullRequestIfSonarFails
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+        run: |
+          PROJECT_KEY=$(grep '^sonar.projectKey=' sonar-project.properties | cut -d '=' -f 2)
+          RESPONSE=$(curl -s -H 'Authorization: Bearer ${{env.SONAR_TOKEN}}' ${{env.SONAR_HOST_URL}}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}\&pullRequest=${{env.PR_NUMBER}})
+          STATUS=$(echo $RESPONSE | jq -r '.projectStatus.status')
+
+          echo "SonarQuality status: $STATUS"
+
+          if [ "$STATUS" == "OK" ]; then
+            exit 0
+          else
+            exit 1
+          fi
+
+  check-if-all-builds-passed:
+    if: always()
+    needs: [ build ]
+    runs-on: [ "self-hosted", "small-builder" ]
+    steps:
+      - name: Check build job failure
+        if: ${{ needs.build.result == 'failure' }}
+        run: exit 1
+
+      - name: Check build job success
+        if: ${{ needs.build.result == 'success' }}
+        run: exit 0
+
+      - name: Slack notification for failed build status
+        uses: hawk-ai-aml/github-actions/send-slack-notification@master
+        if: failure()
+        with:
+          notify-pr-author: true
+          slack-message: ":x: Your build failed. Please check the reason for it."
+          slack-access-token: ${{ secrets.SLACK_RELEASE_BOT_ACCESS_TOKEN }}
+          github-users-access-token: ${{ secrets.USER_GITHUB_ACCESS }}
+
+  vulnerability-check-run:
+    if: ${{ inputs.vulnerabilityCheck == true }}
+    needs: [ init, build ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        image: ${{ fromJson(needs.init.outputs.ecr-images) }}
+
+    steps:
+      - name: Vulnerability check
+        uses: hawk-ai-aml/github-actions/vulnerability-check@master
+        with:
+          ecr-region: ${{ needs.init.outputs.ecr-region }}
+          ecr-registry-code: ${{ needs.init.outputs.ecr-registry-code }}
+          image-name: ${{ matrix.image }}
+          image-tag: ${{ needs.init.outputs.image-tag }}
+          ecr-url: ${{ needs.init.outputs.ecr-url }}
+          aws-access-key-id: ${{ secrets.AWS_ORG_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ORG_ECR_SECRET_ACCESS_KEY }}
+          java-offline-mode: ${{ env.LACEWORK_JAVA_OFFLINE_MODE }}
+          lacework-account-name: ${{ secrets.LACEWORK_ACCOUNT_NAME }}
+          lacework-access-token: ${{ secrets.LACEWORK_ACCESS_TOKEN }}
+
+  update-overlays:
+    needs: [ init, build ]
+    if: ${{ needs.init.outputs.update-kustomize == 'true' && github.workflow != 'pr' }}
+    runs-on: [ "self-hosted", "small-builder" ]
+
+    steps:
+      - name: Update kustomize overlay
+        uses: hawk-ai-aml/github-actions/kustomize-overlay@master
+        with:
+          slack-access-token: ${{ secrets.SLACK_RELEASE_BOT_ACCESS_TOKEN }}
+          github-users-access-token: ${{ secrets.USER_GITHUB_ACCESS }}
+          overlays: ${{ needs.init.outputs.overlays }}
+          modules: ${{ needs.init.outputs.updated-modules-string }}
+          component-name: ${{ inputs.component }}
+          component-tag: ${{ needs.init.outputs.image-tag }}
+          kustomize-repo: hawk-ai-aml/kustomize.git
+          kustomize-access-token: ${{ secrets.REPO_ACCESS_PAT }}
+          ecr-region: ${{ needs.init.outputs.ecr-region }}
+          ecr-registry-code: ${{ needs.init.outputs.ecr-registry-code }}
+          metadata: ${{ needs.init.outputs.metadata }}

--- a/repository-detect-changes/README.md
+++ b/repository-detect-changes/README.md
@@ -1,12 +1,14 @@
 # Detect changes for a repository
-Usage
-```
-        name: Detect changes
-        uses: hawk-ai-aml/github-actions/repository-detect-changes@master
-        with:
-          repository: {{ }}
-          repository-ref: ${{ env.GITHUB_REF_NAME }}
-          repository-user: ${{ secrets.RECREATE_DEVELOP_GITHUB_USER }}
-          repository-access-token: ${{ secrets.REPO_ACCESS_PAT }}
-          modules-string: ${{ }}
+
+Usage:
+
+```yaml
+name: Detect changes
+uses: hawk-ai-aml/github-actions/repository-detect-changes@master
+with:
+  repository: {{ }}
+  repository-ref: ${{ env.GITHUB_REF_NAME }}
+  repository-user: ${{ secrets.RECREATE_DEVELOP_GITHUB_USER }}
+  repository-access-token: ${{ secrets.REPO_ACCESS_PAT }}
+  modules-string: ${{ }}
 ```

--- a/repository-detect-changes/action.yml
+++ b/repository-detect-changes/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: master
 
   repository-user:
-    description: "User can access the repository"
+    description: "User that can access the repository"
     required: true
 
   repository-access-token:
@@ -20,22 +20,22 @@ inputs:
     required: true
 
   modules-string:
-    description: "Module nane in string"
+    description: "Module names as string"
     required: true
 
 outputs:
   updated-modules:
-    description: 'The list of modules has the code changes'
+    description: "The list of modules that have the code changes"
     value: ${{ steps.changes.outputs.updatedModules }}
 
   updated-modules-string:
-    description: 'The list of modules has the code changes in string'
+    description: "The list of modules that have the code changes, as string"
     value: ${{ steps.changes.outputs.updatedModulesString }}
 
 runs:
   using: composite
   steps:
-    - name: Checkout Kustomize
+    - name: Checkout repository
       uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository }}
@@ -137,5 +137,3 @@ runs:
         updatedModules=${MODULES}
         updatedModulesString=${MODULE_LIST_STRING}
         EOF
-
-# End of file


### PR DESCRIPTION
# Description

https://hawkai.atlassian.net/browse/ERS-1958

# Changes

1. Added `build-python-poetry-multi` workflow for testing and building multi-Python services managed by Poetry, instead of Pipenv.