### PR TITLE
ERS-1974 properly run tests in multi-Python workflows

### DIFF
--- a/.github/workflows/build-python-poetry-multi.yaml
+++ b/.github/workflows/build-python-poetry-multi.yaml
@@ -144,10 +144,22 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DEV_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DEV_SECRET_ACCESS_KEY }}
         run: |
-          poetry run pytest \
-            --cov=${{ matrix.module }} \
-            --junitxml=${{ matrix.module }}/report.xml \
-            tests/${{ matrix.module }}
+          MIN_COVERAGE_OVERRIDE_FILE=${{ matrix.module }}/.min-coverage-override
+
+          if [ -f "$MIN_COVERAGE_OVERRIDE_FILE" ]; then
+            poetry run pytest \
+              --cov-reset \
+              --cov=${{ matrix.module }} \
+              --junitxml=${{ matrix.module }}/report.xml \
+              --cov-fail-under=$(cat "$MIN_COVERAGE_OVERRIDE_FILE") \
+              tests/${{ matrix.module }}
+          else
+            poetry run pytest \
+              --cov-reset \
+              --cov=${{ matrix.module }} \
+              --junitxml=${{ matrix.module }}/report.xml \
+              tests/${{ matrix.module }}
+          fi
 
       - name: Generate reports for module
         if: inputs.skipTests != true && (success() || failure())


### PR DESCRIPTION
# Description

There was a bug when running module test using Pipenv. Line like this:

```shell
pipenv run tests --flake8 --cov=${{ matrix.module }} --junitxml=${{ matrix.module }}/report.xml tests/${{ matrix.module }}
```

Would assume that, starting with `--flake8`, all arguments are passed to `pytest`. That's not the case, because we don't invoke `pytest` directly via `pipenv`, like so:

```shell
pipenv run pytest arg1 arg2
```

We actually invoke a `pipenv` script that is defined in `Pipfile`. So instead of running tests for each module, we were running all tests for each module, which was redundant. And it could hide a problem where a module is not tested to the full extent, while other modules could make up for it.

Example workflow run that shows it: https://github.com/hawk-ai-aml/screening-manager/actions/runs/12259660739/job/34202410486#step:8:68

As you can see, even though we wanted to run tests for `screening_import_dow_jones`, all tests were in fact being run.

# Solution

To not break other legacy multi-Python workflows that still use Pipenv, this bug is not addressed here. For Poetry-based projects, this PR fixes that by:
* Adding `--cov-reset` flag to `pytest` invocation, so that we "forget" what was in `pytest.ini` and track coverage for each tested module separately.
* Adding a possibility to override mandatory coverage percentage by each module with a file `.min-coverage-override`. 