### PR TITLE
ci: Enable SonarQube Cloud scan for fronend

### DIFF
--- a/.github/workflows/build-reactjs.yaml
+++ b/.github/workflows/build-reactjs.yaml
@@ -121,7 +121,17 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 1000
+
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GITHUB_REF_NAME }}
+          fetch-depth: 1000
 
       - name: Use Yarn cache
         uses: actions/cache@v3
@@ -153,13 +163,12 @@ jobs:
       - name: Yarn test
         run: yarn run test:ci --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
-      - name: SonarQube Scan
+      - name: SonarQube Cloud Scan
         uses: SonarSource/sonarqube-scan-action@v4
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
-
 
   build:
     needs: [ init, setup-and-lint, tests ]

--- a/.github/workflows/build-reactjs.yaml
+++ b/.github/workflows/build-reactjs.yaml
@@ -153,6 +153,11 @@ jobs:
       - name: Yarn test
         run: yarn run test:ci --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_TOKEN: ${{ secrets. SONARCLOUD_TOKEN }}
+
 
   build:
     needs: [ init, setup-and-lint, tests ]

--- a/.github/workflows/build-reactjs.yaml
+++ b/.github/workflows/build-reactjs.yaml
@@ -156,7 +156,9 @@ jobs:
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v4
         env:
-          SONAR_TOKEN: ${{ secrets. SONARCLOUD_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
 
 
   build:


### PR DESCRIPTION
# Description

- Checkout master and current branch's latest 1k commits for full SonarQube Cloud analysis
- Run SonarQube Cloud step
- Tested here: https://github.com/hawk-ai-aml/frontend/pull/1627