### PR TITLE
ci: Update Sonar Scan action to 4.2.1

### DIFF
--- a/.github/workflows/build-reactjs.yaml
+++ b/.github/workflows/build-reactjs.yaml
@@ -164,7 +164,7 @@ jobs:
         run: yarn run test:ci --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: SonarQube Cloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}


### PR DESCRIPTION
# Description

- Upgrade to 4.2.1 to get rid of the deprecated transitive action dependency on `action/cache`
- Version Upgrade details https://community.sonarsource.com/t/the-new-release-of-github-action-for-sonarqube-v-4-2-server-and-cloud/132269