### PR TITLE
ci: Update to Sonar Scan Action 4.2.1

### DIFF
--- a/.github/workflows/build-python-poetry-multi.yaml
+++ b/.github/workflows/build-python-poetry-multi.yaml
@@ -168,7 +168,7 @@ jobs:
 
       - name: SonarCloud scan
         if: inputs.skipTests != true && (success() || failure()) && inputs.useSonarCloud
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         with:
           args: >
             -Dsonar.python.version=${{ fromJson(needs.init.outputs.metadata).python-version }}


### PR DESCRIPTION
# Description
- Action upgrade details  https://community.sonarsource.com/t/the-new-release-of-github-action-for-sonarqube-v-4-2-server-and-cloud/132269
- Fixes the deprecation of the `action/cache`  https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down