### PR TITLE
fix: Use the project root as the default base directory

### DIFF
--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -150,7 +150,6 @@ jobs:
         with:
           args: >
             -Dsonar.python.version=${{ fromJson(needs.init.outputs.metadata).python-version }}
-          projectBaseDir: ${{ matrix.module }}/
           sonarToken: ${{ secrets.SONAR_TOKEN }}
           sonarHostUrl: ${{ secrets.SONAR_HOST_URL }}
 


### PR DESCRIPTION
- There is no need to define the baseDir for single-module Python projects as the default baseDir is the root of the project
