### PR TITLE
Fix(PE-4356): Automatically increment the version number if duplicated tag exists

### DIFF
--- a/auto-tagging/action.yml
+++ b/auto-tagging/action.yml
@@ -36,6 +36,7 @@ runs:
         PR_LABELS=$(get_pr_labels "$GITHUB_REPOSITORY" "$PR_NUMBER" "$GITHUB_TOKEN")
 
         # Get the latest available tag and ensures that the command doesn't fail if no tags exist
+        # The command `git describe --tags --abbrev=0 2>/dev/null || true` cannot handle multiple tags for the same commit
         LATEST_TAG=$(git tag --sort=committerdate | tail -1 || true)
         if [ -z "$LATEST_TAG" ]; then
           echo "No tags found. Creating tag 0.0.1"


### PR DESCRIPTION
### Title
Follow the [Conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) structure

Current solution uses commiterdate to check which tag is more recent. 

![image](https://github.com/user-attachments/assets/5c9904ac-568f-4656-adbb-a31e2669c40b)

It seems like both tags have the same date but when using the new solution - it will print out 0.0.40. I am not entirely sure that it will work on all cases but we can try it out. It will certainly not break anything since the logic is the same.

I am replacing: 

git describe --tags --abbrev=0 2>/dev/null

with

git tag --sort=committerdate | tail -1

Output: 

![image](https://github.com/user-attachments/assets/d018e452-f7c1-4a6e-9f89-f46666166a4b)


### Risk Assessment
impact:1 * likelyhood:1 = risk:1

### Story Link
https://hawkai.atlassian.net/browse/

### Checklist
- [x] Verify your changes on dev if needed.
