### PR TITLE
Hotfix(): autotag-duplicate

### DIFF
--- a/auto-tagging/action.yml
+++ b/auto-tagging/action.yml
@@ -37,7 +37,7 @@ runs:
 
         # Get the latest available tag and ensures that the command doesn't fail if no tags exist
         # The command `git describe --tags --abbrev=0 2>/dev/null || true` cannot handle multiple tags for the same commit
-        LATEST_TAG=$(git tag --sort=committerdate | tail -1 || true)
+        LATEST_TAG=$(git tag --sort=committerdate | tail -2 | sort -V | tail -1 || true) # Get the last 2 tags and sort them, then get the last one
         if [ -z "$LATEST_TAG" ]; then
           echo "No tags found. Creating tag 0.0.1"
           LATEST_TAG=0.0.0


### PR DESCRIPTION
### Title
Follow the [Conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) structure

I have tested the new command by comparing the last two versions and always take the bigger tag lexically using sort -V.

![image](https://github.com/user-attachments/assets/f7c480ba-b87b-488b-8f87-65f692e787ce)

Testing with minor version increase:

![image](https://github.com/user-attachments/assets/3eebdf0a-0521-46f5-ad1d-43707ee7c0c9)

![image](https://github.com/user-attachments/assets/e9cdab0f-b3e9-42b8-ab64-feb059a9f1ec)


Testing with major version increase:

![image](https://github.com/user-attachments/assets/e9b8f478-fde1-45b7-86d0-ba10cfe6f632)



# What happens if there are no tags or only one tag? 

Should work.

![image](https://github.com/user-attachments/assets/0c7a1781-7292-46f1-8854-7157ac7255f4)

### Risk Assessment
impact:1 * likelyhood:1 = risk:1

### Story Link
https://hawkai.atlassian.net/browse/

### Checklist
- [x] Verify your changes on dev if needed.
