### PR TITLE
Skip SonarQube Cloud Scan for frontend builds except PR

### DIFF
--- a/.github/workflows/build-reactjs.yaml
+++ b/.github/workflows/build-reactjs.yaml
@@ -160,7 +160,7 @@ jobs:
           node-version: '^22.12.0'
 
       - name: SonarQube Cloud Scan
-        if: ${{ github.workflow == 'pr' || github.workflow == 'master' }}
+        if: ${{ github.workflow == 'pr' }}
         uses: hawk-ai-aml/github-actions/sonarqube@master
         with:
           sonarToken: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
frontend tag and develop builds are failing due to sonarqube cloud incident
sonar community incident thread - https://community.sonarsource.com/t/sonarqube-cloud-java-net-sockettimeoutexception-timeout/145852/37

failed: https://github.com/hawk-ai-aml/frontend/actions/runs/16771406641/job/47490328440
test build with this change: https://github.com/hawk-ai-aml/frontend/actions/runs/16773355247
 
<img width="932" height="712" alt="image" src="https://github.com/user-attachments/assets/4405d628-d99b-4525-8980-0df254549aed" />



