### PR TITLE
feat(DC-2274): Remove question about `rollback plan`

### DIFF
--- a/risk-assessment/config/risk-questions.json
+++ b/risk-assessment/config/risk-questions.json
@@ -35,11 +35,6 @@
       "question": "Does this change activate a feature flag that exposes a significant new feature to users?"
     },
     {
-      "key": "rollback",
-      "maxWeight": 1,
-      "question": "Does this change lack a documented, tested rollback plan?"
-    },
-    {
       "key": "apiIncompatibility",
       "maxWeight": 2.5,
       "question": "Does this change introduce changes to an API used by other services that make it not forwards compatible?"


### PR DESCRIPTION
# Description

https://hawkai.atlassian.net/browse/DC-2274

# Evidence
No `rollback plan` question any more:
<img width="1338" height="1536" alt="image" src="https://github.com/user-attachments/assets/40695687-bf2d-4053-a3bd-fcbc974a8d93" />

