### PR TITLE
feat(DC-2307): Enable SRA for all repos with call to enforce-labels

### DIFF
--- a/enforce-labels/action.yml
+++ b/enforce-labels/action.yml
@@ -26,9 +26,47 @@ inputs:
     default: "impact 2 * likelyhood 2 = risk 4;impact 2 * likelyhood 3 = risk 6;impact 3 * likelyhood 2 = risk 6;impact 3 * likelyhood 3 = risk 9"
     required: false
 
+  enable-risk-assessment:
+    description: "Enable risk assessment integration"
+    required: false
+    default: "true"
+
+  sra-enforce-mode:
+    description: "Whether to enforce risk assessment results"
+    required: false
+    default: "false"
+
+  github-actions-ref:
+    description: "Branch/ref to use for github-actions repository"
+    required: false
+    default: "master"
+
+outputs:
+  risk-score:
+    description: "Calculated risk score from assessment"
+    value: ${{ steps.risk-assessment.outputs.risk-score }}
+  risk-tier:
+    description: "Risk tier from assessment"
+    value: ${{ steps.risk-assessment.outputs.risk-tier }}
+  assessment-status:
+    description: "Risk assessment status"
+    value: ${{ steps.risk-assessment.outputs.status }}
+
 runs:
   using: composite
   steps:
+    - name: Run Risk Assessment
+      if: ${{ inputs.enable-risk-assessment == 'true' }}
+      id: risk-assessment
+      continue-on-error: true
+      uses: hawk-ai-aml/github-actions/.github/workflows/risk-assessment.yml@${{ inputs.github-actions-ref }}
+      with:
+        sra-enabled: true
+        enforce-mode: ${{ inputs.sra-enforce-mode }}
+        github-actions-ref: ${{ inputs.github-actions-ref }}
+      secrets:
+        github-token: ${{ inputs.repository-access-token }}
+
     - name: Check required labels
       shell: bash -l -ET -eo pipefail {0}
       env:

--- a/enforce-labels/action.yml
+++ b/enforce-labels/action.yml
@@ -59,12 +59,11 @@ runs:
       if: ${{ inputs.enable-risk-assessment == 'true' }}
       id: risk-assessment
       continue-on-error: true
-      uses: hawk-ai-aml/github-actions/.github/workflows/risk-assessment.yml@${{ inputs.github-actions-ref }}
+      uses: hawk-ai-aml/github-actions/risk-assessment@${{ inputs.github-actions-ref }}
       with:
         sra-enabled: true
         enforce-mode: ${{ inputs.sra-enforce-mode }}
         github-actions-ref: ${{ inputs.github-actions-ref }}
-      secrets:
         github-token: ${{ inputs.repository-access-token }}
 
     - name: Check required labels

--- a/enforce-labels/action.yml
+++ b/enforce-labels/action.yml
@@ -1,5 +1,5 @@
 name: enforce-labels
-description: Enforce labels for pull request
+description: Enforce labels for pull request and perform risk assessment
 
 inputs:
   repository-ref:
@@ -26,45 +26,35 @@ inputs:
     default: "impact 2 * likelyhood 2 = risk 4;impact 2 * likelyhood 3 = risk 6;impact 3 * likelyhood 2 = risk 6;impact 3 * likelyhood 3 = risk 9"
     required: false
 
-  enable-risk-assessment:
-    description: "Enable risk assessment integration"
+  sra-enabled:
+    description: 'Enable or disable the entire risk assessment workflow'
     required: false
-    default: "true"
+    default: 'true'
 
-  sra-enforce-mode:
-    description: "Whether to enforce risk assessment results"
+  enforce-mode:
+    description: 'Whether to enforce risk assessment results'
     required: false
-    default: "false"
+    default: 'false'
 
   github-actions-ref:
-    description: "Branch/ref to use for github-actions repository"
+    description: 'Branch/ref to use for hawk-ai-aml/github-actions repository'
     required: false
-    default: "master"
+    default: 'master'
 
 outputs:
   risk-score:
-    description: "Calculated risk score from assessment"
+    description: 'Calculated risk score'
     value: ${{ steps.risk-assessment.outputs.risk-score }}
   risk-tier:
-    description: "Risk tier from assessment"
+    description: 'Risk tier'
     value: ${{ steps.risk-assessment.outputs.risk-tier }}
-  assessment-status:
-    description: "Risk assessment status"
+  status:
+    description: 'Assessment status'
     value: ${{ steps.risk-assessment.outputs.status }}
 
 runs:
   using: composite
   steps:
-    - name: Run Risk Assessment
-      if: ${{ inputs.enable-risk-assessment == 'true' }}
-      id: risk-assessment
-      continue-on-error: true
-      uses: hawk-ai-aml/github-actions/risk-assessment@${{ inputs.github-actions-ref }}
-      with:
-        sra-enabled: true
-        enforce-mode: ${{ inputs.sra-enforce-mode }}
-        github-actions-ref: ${{ inputs.github-actions-ref }}
-        github-token: ${{ inputs.repository-access-token }}
 
     - name: Check required labels
       shell: bash -l -ET -eo pipefail {0}
@@ -151,3 +141,77 @@ runs:
         else
             echo "All label sets passed the check."
         fi
+
+    - name: Checkout calling repository
+      if: ${{ inputs.sra-enabled == 'true' && !github.event.pull_request.draft }}
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Checkout github actions for risk assessment
+      if: ${{ inputs.sra-enabled == 'true' && !github.event.pull_request.draft }}
+      uses: actions/checkout@v4
+      with:
+        repository: hawk-ai-aml/github-actions
+        path: .github-actions
+        ref: ${{ inputs.github-actions-ref }}
+        token: ${{ inputs.repository-access-token }}
+
+    - name: Send workflow start metric
+      id: metrics-start
+      if: ${{ inputs.sra-enabled == 'true' && !github.event.pull_request.draft }}
+      continue-on-error: true
+      uses: ./.github-actions/workflow-metrics
+      with:
+        action: start
+        grouping-keys: |
+          job: github_risk_assessment
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
+        labels: |
+          github_actions_ref: ${{ inputs.github-actions-ref }}
+          sra_enabled: ${{ inputs.sra-enabled }}
+          enforce_mode: ${{ inputs.enforce-mode }}
+
+    - name: Load Risk Questions Config
+      id: load-config
+      if: ${{ inputs.sra-enabled == 'true' && !github.event.pull_request.draft }}
+      shell: bash
+      run: |
+        CONFIG_PATH=".github-actions/risk-assessment/config/risk-questions.json"
+
+        # Read and encode config as base64
+        CONFIG_B64=$(cat "$CONFIG_PATH" | base64 -w 0)
+        echo "config-b64=$CONFIG_B64" >> $GITHUB_OUTPUT
+
+    - name: Run Risk Assessment
+      id: risk-assessment
+      if: ${{ inputs.sra-enabled == 'true' && !github.event.pull_request.draft }}
+      uses: ./.github-actions/risk-assessment
+      env:
+        SRA_ENFORCE_MODE: ${{ inputs.enforce-mode }}
+      with:
+        github-token: ${{ inputs.repository-access-token }}
+        config: ${{ steps.load-config.outputs.config-b64 }}
+
+    - name: Send workflow completion metric
+      id: metrics-complete
+      if: ${{ always() && inputs.sra-enabled == 'true' && !github.event.pull_request.draft }}
+      continue-on-error: true
+      uses: ./.github-actions/workflow-metrics
+      with:
+        action: complete
+        grouping-keys: |
+          job: github_risk_assessment
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          fallback: ${{ steps.risk-assessment.outputs.fallback }}
+        labels: |
+          github_actions_ref: ${{ inputs.github-actions-ref }}
+          sra_enabled: ${{ inputs.sra-enabled }}
+          enforce_mode: ${{ inputs.enforce-mode }}
+          tier: ${{ steps.risk-assessment.outputs.risk-tier || 'unknown' }}
+          status: ${{ job.status || 'unknown' }}
+        additional-metrics: |
+          github_risk_assessment_score: ${{ steps.risk-assessment.outputs.risk-score || '-1' }}
+        start-time: ${{ steps.metrics-start.outputs.start-time }}

--- a/enforce-labels/action.yml
+++ b/enforce-labels/action.yml
@@ -144,12 +144,14 @@ runs:
 
     - name: Checkout calling repository
       if: ${{ inputs.sra-enabled == 'true' && !github.event.pull_request.draft }}
+      continue-on-error: true
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Checkout github actions for risk assessment
       if: ${{ inputs.sra-enabled == 'true' && !github.event.pull_request.draft }}
+      continue-on-error: true
       uses: actions/checkout@v4
       with:
         repository: hawk-ai-aml/github-actions
@@ -176,6 +178,7 @@ runs:
     - name: Load Risk Questions Config
       id: load-config
       if: ${{ inputs.sra-enabled == 'true' && !github.event.pull_request.draft }}
+      continue-on-error: true
       shell: bash
       run: |
         CONFIG_PATH=".github-actions/risk-assessment/config/risk-questions.json"
@@ -187,6 +190,7 @@ runs:
     - name: Run Risk Assessment
       id: risk-assessment
       if: ${{ inputs.sra-enabled == 'true' && !github.event.pull_request.draft }}
+      continue-on-error: true
       uses: ./.github-actions/risk-assessment
       env:
         SRA_ENFORCE_MODE: ${{ inputs.enforce-mode }}


### PR DESCRIPTION
# Description
https://hawkai.atlassian.net/browse/DC-2307

# Evidence
The action now runs as part of the labels check:
https://github.com/hawk-ai-aml/platform-statistics/actions/runs/17487281807/job/49668870569?pr=108
```
Run hawk-ai-aml/github-actions/enforce-labels@feature/DC-2307
Run get_pr_number() {
/home/builder/.bashrc: line 38: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
Required label impact 1 * likelyhood 1 = risk 1 found!
Required label patch-version found!
All label sets passed the check.
Run actions/checkout@v4
Syncing repository: hawk-ai-aml/platform-statistics
Getting Git version info
Copying '/home/builder/.gitconfig' to '/runner/_work/_temp/9b4e29bd-ec5b-47fe-971d-37377ba19a3d/.gitconfig'
Temporarily overriding HOME='/runner/_work/_temp/9b4e29bd-ec5b-47fe-971d-37377ba19a3d' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /runner/_work/platform-statistics/platform-statistics
Deleting the contents of '/runner/_work/platform-statistics/platform-statistics'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
Determining the checkout info
/usr/bin/git sparse-checkout disable
/usr/bin/git config --local --unset-all extensions.worktreeConfig
Checking out the ref
/usr/bin/git log -1 --format=%H
816a547a45757fe4fe6b7bb48a5a1b26bf963345
Run actions/checkout@v4
Syncing repository: hawk-ai-aml/github-actions
Getting Git version info
Copying '/home/builder/.gitconfig' to '/runner/_work/_temp/dcd1a43d-9a43-4817-aaa8-fd4b2cad476d/.gitconfig'
Temporarily overriding HOME='/runner/_work/_temp/dcd1a43d-9a43-4817-aaa8-fd4b2cad476d' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /runner/_work/platform-statistics/platform-statistics/.github-actions
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
Determining the checkout info
/usr/bin/git sparse-checkout disable
/usr/bin/git config --local --unset-all extensions.worktreeConfig
Checking out the ref
/usr/bin/git log -1 --format=%H
c7687c0d3c02cdaec92153a27cfc46c30c29d92d
Prepare all required actions
Run ./.github-actions/workflow-metrics
Run python3 "/runner/_work/platform-statistics/platform-statistics/./.github-actions/workflow-metrics/scripts/send_start_metrics.py" \
2025-09-05 07:57:36 - workflow-metrics - INFO - === Script Inputs ===
2025-09-05 07:57:36 - workflow-metrics - INFO - Arguments: {'pushgateway_url': 'http://prometheus-pushgateway.monitoring:9091/metrics', 'grouping_keys': 'job: github_risk_assessment\nrepository: hawk-ai-aml/platform-statistics\nref: refs/pull/108/merge\n', 'labels': 'github_actions_ref: feature/DC-2307\nsra_enabled: true\nenforce_mode: true\n', 'additional_metrics': '', 'start_time': None}
2025-09-05 07:57:36 - workflow-metrics - INFO - =====================
2025-09-05 07:57:36 - workflow-metrics - INFO - Parsed inputs: ScriptInputs(pushgateway_url='http://prometheus-pushgateway.monitoring:9091/metrics', grouping_keys={'job': ['github_risk_assessment'], 'repository': ['hawk-ai-aml_platform-statistics'], 'ref': ['refs_pull_108_merge']}, labels={'github_actions_ref': 'feature/DC-2307', 'sra_enabled': 'true', 'enforce_mode': 'true'}, additional_metrics=None, start_time=None)
2025-09-05 07:57:36 - workflow-metrics - INFO - Start time: 1757059056
2025-09-05 07:57:36 - workflow-metrics - INFO - Sending metrics to: http://prometheus-pushgateway.monitoring:9091/metrics/job/github_risk_assessment/repository/hawk-ai-aml_platform-statistics/ref/refs_pull_108_merge
2025-09-05 07:57:36 - workflow-metrics - INFO - === Request Details ===
2025-09-05 07:57:36 - workflow-metrics - INFO - URL: http://prometheus-pushgateway.monitoring:9091/metrics/job/github_risk_assessment/repository/hawk-ai-aml_platform-statistics/ref/refs_pull_108_merge
2025-09-05 07:57:36 - workflow-metrics - INFO - Method: POST
2025-09-05 07:57:36 - workflow-metrics - INFO - Content-Type: text/plain
2025-09-05 07:57:36 - workflow-metrics - INFO - Timeout: 10 seconds
2025-09-05 07:57:36 - workflow-metrics - INFO - Max retries: 2
2025-09-05 07:57:36 - workflow-metrics - INFO - ========================
2025-09-05 07:57:36 - workflow-metrics - INFO - === Metrics to be sent to Prometheus ===
2025-09-05 07:57:36 - workflow-metrics - INFO - 
workflow_last_start_timestamp{github_actions_ref="feature/DC-2307",sra_enabled="true",enforce_mode="true"} 1757059056

2025-09-05 07:57:36 - workflow-metrics - INFO - ========================================
2025-09-05 07:57:36 - workflow-metrics - INFO - HTTP response code: 200
Run CONFIG_PATH=".github-actions/risk-assessment/config/risk-questions.json"
Run ./.github-actions/risk-assessment
Gathering PR context and changed files...
📊 Starting PR context gathering...
📂 Fetched 4 files in 432ms
File change statistics:
[
  {
    "filename": ".github/workflows/pr-labels.yaml",
    "status": "modified",
    "additions": 4,
    "deletions": 4,
    "changes": 8,
    "patchSize": 738
  },
  {
    "filename": ".github/workflows/pr.yaml",
    "status": "removed",
    "additions": 0,
    "deletions": 15,
    "changes": 15,
    "patchSize": 345
  },
  {
    "filename": ".github/workflows/risk-assessment.yaml",
    "status": "removed",
    "additions": 0,
    "deletions": 22,
    "changes": 22,
    "patchSize": 501
  },
  {
    "filename": "app/src/main/java/tech/hawkai/platform_statistics/controller/AggregatesReportingController.java",
    "status": "modified",
    "additions": 3,
    "deletions": 1,
    "changes": 4,
    "patchSize": 564
  }
]
📏 Total patch size: 2148 characters
✅ PR context gathering complete - Processing: 0ms, Total: 434ms
📊 Selected 4 files for analysis
📋 Summarized 0 large files
PR Context: feat(DC-2253): Demo Changes
Files analyzed: 4/4
Performing AI risk assessment...
🚀 Starting AI risk assessment...
Attempting risk assessment with primary model (gpt-4.1)
Running AI inference without tools
Model response received: Success
Primary model success - Duration: 28607ms
Raw AI response: {
  "authentication": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "schema": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "performance": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "dependencies": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "libraries": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "features": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "apiIncompatibility": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "code": {
    "evidence": "https://github.com/hawk-ai-aml/platform-statistics/blob/feature/DC-2253/app/src/main/java/tech/hawkai/platform_statistics/controller/AggregatesReportingController.java#L38",
    "answer": "Yes",
    "weight": "0.2"
  },
  "devEnvironment": {
    "evidence": "Checked: 'I deployed the change to DEV and checked that it is working, it is not breaking anything and it doesn't produce exceptions' is NOT ticked in PR description",
    "answer": "Yes",
    "weight": "2"
  }
}
Parsed risk factors: {
  "codeChurn": -1,
  "cognitiveComplexity": -1,
  "authentication": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "schema": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "performance": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "dependencies": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "libraries": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "features": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "apiIncompatibility": {
    "evidence": "❌",
    "answer": "No",
    "weight": "0"
  },
  "code": {
    "evidence": "https://github.com/hawk-ai-aml/platform-statistics/blob/feature/DC-2253/app/src/main/java/tech/hawkai/platform_statistics/controller/AggregatesReportingController.java#L38",
    "answer": "Yes",
    "weight": "0.2"
  },
  "devEnvironment": {
    "evidence": "Checked: 'I deployed the change to DEV and checked that it is working, it is not breaking anything and it doesn't produce exceptions' is NOT ticked in PR description",
    "answer": "Yes",
    "weight": "2"
  }
}
Relevant files: app/src/main/java/tech/hawkai/platform_statistics/controller/AggregatesReportingController.java
Relevant files: app/src/main/java/tech/hawkai/platform_statistics/controller/AggregatesReportingController.java
Diff Output length: 3143
Parsed file changes: {
  ".github/workflows/pr-labels.yaml": [
    "        uses: hawk-ai-aml/github-actions/enforce-labels@feature/DC-2307",
    "          github-actions-ref: feature/DC-2307",
    "          enforce-mode: true",
    "          sra-enabled: true"
  ],
  "app/src/main/java/tech/hawkai/platform_statistics/controller/AggregatesReportingController.java": [
    "        log.debug(\"getPlatformStatisticsAggregatesReport\");",
    "            .map(ResponseEntity::ok)",
    "            .map(aggregatesReportResponseEntity -> aggregatesReportResponseEntity);"
  ]
}
File app/src/main/java/tech/hawkai/platform_statistics/controller/AggregatesReportingController.java: Cognitive complexity 0.30 (from 3 added lines)
Cognitive complexity calculation: 1 files, sum: 0.30, normalized score: 0.30/10
Calculated cognitive complexity: 0.3010299956639812
Log result: {
  "all": [
    {
      "hash": "e1da262 test(DC-2253): small change\n1eb12ec DC-1742: Add endpoint to get verification data for powerBI (#97)\n6fda193 DC-1813: Add logic to fetch aggregates report (#79)\n6310e42 DC-1813: Code refactor",
      "date": "",
      "message": "",
      "refs": "",
      "body": "",
      "author_name": "",
      "author_email": ""
    }
  ],
  "latest": {
    "hash": "e1da262 test(DC-2253): small change\n1eb12ec DC-1742: Add endpoint to get verification data for powerBI (#97)\n6fda193 DC-1813: Add logic to fetch aggregates report (#79)\n6310e42 DC-1813: Code refactor",
    "date": "",
    "message": "",
    "refs": "",
    "body": "",
    "author_name": "",
    "author_email": ""
  },
  "total": 1
}
Log result: {
  "all": [
    {
      "hash": "e1da262 test(DC-2253): small change\n1eb12ec DC-1742: Add endpoint to get verification data for powerBI (#97)\n6fda193 DC-1813: Add logic to fetch aggregates report (#79)\n6310e42 DC-1813: Code refactor",
      "date": "",
      "message": "",
      "refs": "",
      "body": "",
      "author_name": "",
      "author_email": ""
    }
  ],
  "latest": {
    "hash": "e1da262 test(DC-2253): small change\n1eb12ec DC-1742: Add endpoint to get verification data for powerBI (#97)\n6fda193 DC-1813: Add logic to fetch aggregates report (#79)\n6310e42 DC-1813: Code refactor",
    "date": "",
    "message": "",
    "refs": "",
    "body": "",
    "author_name": "",
    "author_email": ""
  },
  "total": 1
}
File app/src/main/java/tech/hawkai/platform_statistics/controller/AggregatesReportingController.java: 1 change (new file), churn score: 0.10
Code churn calculation: 1 files analyzed, average churn score: 0.10
Calculated code churn: 0.1
Calculated risk score: 2.36
Determined risk tier: {"name":"Medium","minScore":2,"status":"success","message":"⏸️ Code Owner review recommended."}
Generated risk comment: # 🔍 Risk Assessment Results

<div style="text-align: center;">

# Risk Level: **Medium**

## **Score: 2.36**

### ⏸️ Code Owner review recommended.

### _This tool can make mistakes. Please review the results carefully and use your judgment to assess the risk level of this code._

</div>

<details>
<summary>📊 Automated Metrics</summary>

| Metric                   | Value                   | Points Added                   | Weight                        |
|--------------------------|-------------------------|--------------------------------|-------------------------------|
| **Code Churn**           | 0.1           | +0.04           | 0.4           |
| **Cognitive Complexity** | 0.3 | +0.12 | 0.4 |

</details>

<details>
<summary>📔 Assessment Results</summary>

| Question | Answer | Weight | Evidence |
|----------|--------|--------|----------|
| Does this change involve modifications to authentication, authorization, or user permission logic? | No ✅ | 0 | ❌ |
| Does this change introduce new, or alter existing, database schemas, tables, or columns? | No ✅ | 0 | ❌ |
| Does this change add database queries with missing indexes, N+1 queries, or queries over large datasets without pagination? | No ✅ | 0 | ❌ |
| Does this change update dependencies (Any lib: major/minor versions; Core framework updates like Spring Boot/Cloud: major/minor/patch)? | No ✅ | 0 | ❌ |
| Does this change involve modifications to internal libraries or shared components? Are they used frequently across the repository? | No ✅ | 0 | ❌ |
| Does this change activate a feature flag that exposes a significant new feature to users? | No ✅ | 0 | ❌ |
| Does this change introduce changes to an API used by other services that make it not forwards compatible? | No ✅ | 0 | ❌ |
| Are there new linting suppressions, TODO comments, or deprecated API usage? | Yes ⚠️ | 0.2 | https://github.com/hawk-ai-aml/platform-statistics/blob/feature/DC-2253/app/src/main/java/tech/hawkai/platform_statistics/controller/AggregatesReportingController.java#L38 |
| Is this change yet to be deployed to a development environment for testing? | Yes ⚠️ | 2 | Checked: 'I deployed the change to DEV and checked that it is working, it is not breaking anything and it doesn't produce exceptions' is NOT ticked in PR description |

</details>

<sub>🤖 This assessment was generated automatically. For questions about the risk assessment process, please contact your
development team leads.</sub>
Found 2 existing comments on PR #108
Prepare all required actions
Run ./.github-actions/workflow-metrics
Run python3 "/runner/_work/platform-statistics/platform-statistics/./.github-actions/workflow-metrics/scripts/send_completion_metrics.py" \
2025-09-05 07:58:07 - workflow-metrics - INFO - === Script Inputs ===
2025-09-05 07:58:07 - workflow-metrics - INFO - Arguments: {'pushgateway_url': 'http://prometheus-pushgateway.monitoring:9091/metrics', 'grouping_keys': 'job: github_risk_assessment\nrepository: hawk-ai-aml/platform-statistics\nref: refs/pull/108/merge\nfallback: \n', 'labels': 'github_actions_ref: feature/DC-2307\nsra_enabled: true\nenforce_mode: true\ntier: Medium\nstatus: success\n', 'additional_metrics': 'github_risk_assessment_score: 2.36\n', 'start_time': '1757059056'}
2025-09-05 07:58:07 - workflow-metrics - INFO - =====================
2025-09-05 07:58:07 - workflow-metrics - INFO - Parsed inputs: ScriptInputs(pushgateway_url='http://prometheus-pushgateway.monitoring:9091/metrics', grouping_keys={'job': ['github_risk_assessment'], 'repository': ['hawk-ai-aml_platform-statistics'], 'ref': ['refs_pull_108_merge'], 'fallback': ['']}, labels={'github_actions_ref': 'feature/DC-2307', 'sra_enabled': 'true', 'enforce_mode': 'true', 'tier': 'Medium', 'status': 'success'}, additional_metrics={'github_risk_assessment_score': 2.36}, start_time='1757059056')
2025-09-05 07:58:07 - workflow-metrics - INFO - Duration: 31 seconds
2025-09-05 07:58:07 - workflow-metrics - INFO - Sending metrics to: http://prometheus-pushgateway.monitoring:9091/metrics/job/github_risk_assessment/repository/hawk-ai-aml_platform-statistics/ref/refs_pull_108_merge/fallback/
2025-09-05 07:58:07 - workflow-metrics - INFO - === Request Details ===
2025-09-05 07:58:07 - workflow-metrics - INFO - URL: http://prometheus-pushgateway.monitoring:9091/metrics/job/github_risk_assessment/repository/hawk-ai-aml_platform-statistics/ref/refs_pull_108_merge/fallback/
2025-09-05 07:58:07 - workflow-metrics - INFO - Method: POST
2025-09-05 07:58:07 - workflow-metrics - INFO - Content-Type: text/plain
2025-09-05 07:58:07 - workflow-metrics - INFO - Timeout: 10 seconds
2025-09-05 07:58:07 - workflow-metrics - INFO - Max retries: 2
2025-09-05 07:58:07 - workflow-metrics - INFO - ========================
2025-09-05 07:58:07 - workflow-metrics - INFO - === Metrics to be sent to Prometheus ===
2025-09-05 07:58:07 - workflow-metrics - INFO - 
workflow_last_completion_timestamp{github_actions_ref="feature/DC-2307",sra_enabled="true",enforce_mode="true",tier="Medium",status="success"} 1757059087
workflow_duration_seconds{github_actions_ref="feature/DC-2307",sra_enabled="true",enforce_mode="true",tier="Medium",status="success"} 31
github_risk_assessment_score{github_actions_ref="feature/DC-2307",sra_enabled="true",enforce_mode="true",tier="Medium",status="success"} 2.36

2025-09-05 07:58:07 - workflow-metrics - INFO - ========================================
2025-09-05 07:58:07 - workflow-metrics - INFO - HTTP response code: 200
```