### PR TITLE
chore(PE-4932): Remove lacework from vulnerability check action

### DIFF
--- a/.github/workflows/build-java-multi.yaml
+++ b/.github/workflows/build-java-multi.yaml
@@ -369,8 +369,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ORG_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ORG_ECR_SECRET_ACCESS_KEY }}
           java-offline-mode: ${{ env.LACEWORK_JAVA_OFFLINE_MODE }}
-          lacework-account-name: ${{ secrets.LACEWORK_ACCOUNT_NAME }}
-          lacework-access-token: ${{ secrets.LACEWORK_ACCESS_TOKEN }}
 
   update-overlays:
     needs: [ init, build ]

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -288,8 +288,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ORG_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ORG_ECR_SECRET_ACCESS_KEY }}
           java-offline-mode: ${{ env.LACEWORK_JAVA_OFFLINE_MODE }}
-          lacework-account-name: ${{ secrets.LACEWORK_ACCOUNT_NAME }}
-          lacework-access-token: ${{ secrets.LACEWORK_ACCESS_TOKEN }}
 
   update-overlays:
     needs: [ init, build ]

--- a/.github/workflows/build-python-multi.yaml
+++ b/.github/workflows/build-python-multi.yaml
@@ -316,8 +316,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ORG_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ORG_ECR_SECRET_ACCESS_KEY }}
           java-offline-mode: ${{ env.LACEWORK_JAVA_OFFLINE_MODE }}
-          lacework-account-name: ${{ secrets.LACEWORK_ACCOUNT_NAME }}
-          lacework-access-token: ${{ secrets.LACEWORK_ACCESS_TOKEN }}
 
   update-overlays:
     needs: [ init, build ]

--- a/.github/workflows/build-python-poetry-multi.yaml
+++ b/.github/workflows/build-python-poetry-multi.yaml
@@ -336,8 +336,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ORG_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ORG_ECR_SECRET_ACCESS_KEY }}
           java-offline-mode: ${{ env.LACEWORK_JAVA_OFFLINE_MODE }}
-          lacework-account-name: ${{ secrets.LACEWORK_ACCOUNT_NAME }}
-          lacework-access-token: ${{ secrets.LACEWORK_ACCESS_TOKEN }}
 
   update-overlays:
     needs: [ init, build ]

--- a/.github/workflows/build-python-poetry.yaml
+++ b/.github/workflows/build-python-poetry.yaml
@@ -300,8 +300,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ORG_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ORG_ECR_SECRET_ACCESS_KEY }}
           java-offline-mode: ${{ env.LACEWORK_JAVA_OFFLINE_MODE }}
-          lacework-account-name: ${{ secrets.LACEWORK_ACCOUNT_NAME }}
-          lacework-access-token: ${{ secrets.LACEWORK_ACCESS_TOKEN }}
 
   update-overlays:
     needs: [ init, build ]

--- a/.github/workflows/build-python-uv.yaml
+++ b/.github/workflows/build-python-uv.yaml
@@ -292,8 +292,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ORG_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ORG_ECR_SECRET_ACCESS_KEY }}
           java-offline-mode: ${{ env.LACEWORK_JAVA_OFFLINE_MODE }}
-          lacework-account-name: ${{ secrets.LACEWORK_ACCOUNT_NAME }}
-          lacework-access-token: ${{ secrets.LACEWORK_ACCESS_TOKEN }}
 
   update-overlays:
     needs: [init, build]

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -244,8 +244,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ORG_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ORG_ECR_SECRET_ACCESS_KEY }}
           java-offline-mode: ${{ env.LACEWORK_JAVA_OFFLINE_MODE }}
-          lacework-account-name: ${{ secrets.LACEWORK_ACCOUNT_NAME }}
-          lacework-access-token: ${{ secrets.LACEWORK_ACCESS_TOKEN }}
 
   update-overlays:
     needs: [ init, build ]

--- a/.github/workflows/build-reactjs.yaml
+++ b/.github/workflows/build-reactjs.yaml
@@ -253,8 +253,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ORG_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ORG_ECR_SECRET_ACCESS_KEY }}
           java-offline-mode: ${{ env.LACEWORK_JAVA_OFFLINE_MODE }}
-          lacework-account-name: ${{ secrets.LACEWORK_ACCOUNT_NAME }}
-          lacework-access-token: ${{ secrets.LACEWORK_ACCESS_TOKEN }}
 
   update-overlays:
     needs: [ init, setup-and-lint, tests, build ]

--- a/vulnerability-check/action.yml
+++ b/vulnerability-check/action.yml
@@ -34,48 +34,31 @@ inputs:
     description: "Java offline mode"
     required: true
 
-  lacework-account-name:
-    description: "Lacework account name"
-    required: true
-
-  lacework-access-token:
-    description: "Lacework access token"
-    required: true
-
 runs:
   using: composite
   steps:
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        aws-region: ${{ inputs.ecr-region }}
+    - name: Placeholder for future vulnerability check
+      run: echo "Future vulnerability checks to go here"
 
-    - name: Login to Amazon ECR
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
-      with:
-        registries: ${{ inputs.ecr-registry-code }}
+    #- name: Configure AWS credentials
+    #  uses: aws-actions/configure-aws-credentials@v2
+    #  with:
+    #    aws-access-key-id: ${{ inputs.aws-access-key-id }}
+    #    aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+    #    aws-region: ${{ inputs.ecr-region }}
 
-    - name: Retrieve AWS ECR login password for Lacework
-      shell: bash -l -ET -eo pipefail {0}
-      id: ecr-password
-      env:
-        ECR_REGION: ${{ inputs.ecr-region }}
-      run: |
-        echo "password=$(aws ecr get-login-password --region ${ECR_REGION})" >> $GITHUB_OUTPUT
+    #- name: Login to Amazon ECR
+    #  id: login-ecr
+    #  uses: aws-actions/amazon-ecr-login@v2
+    #  with:
+    #    registries: ${{ inputs.ecr-registry-code }}
 
-    - uses: lacework/lw-scanner-action@v1.3.2
-      name: Scan container image for vulnerabilities using Lacework
-      env:
-        JAVA_OFFLINE_MODE: ${{ inputs.java-offline-mode }}
-      with:
-        LW_ACCOUNT_NAME: ${{ inputs.lacework-account-name }}
-        LW_ACCESS_TOKEN: ${{ inputs.lacework-access-token }}
-        IMAGE_NAME: ${{ inputs.image-name }}
-        IMAGE_TAG: ${{ inputs.image-tag }}
-        SAVE_RESULTS_IN_LACEWORK: true
-        ADDITIONAL_PARAMETERS: --docker-username AWS --docker-server ${{ inputs.ecr-url }} --docker-password ${{ steps.ecr-password.outputs.password }}
+    #- name: Retrieve AWS ECR login password for vulnerability check
+    #  shell: bash -l -ET -eo pipefail {0}
+    #  id: ecr-password
+    #  env:
+    #    ECR_REGION: ${{ inputs.ecr-region }}
+    #  run: |
+    #    echo "password=$(aws ecr get-login-password --region ${ECR_REGION})" >> $GITHUB_OUTPUT
 
 # End of file


### PR DESCRIPTION
This removes lacework from the github actions.  We leave a placeholder action for future vulnerability checks.