### PR TITLE
ERD-404: Fix docker image build anti-pattern

### DIFF
--- a/.github/workflows/build-python-uv.yaml
+++ b/.github/workflows/build-python-uv.yaml
@@ -278,7 +278,7 @@ jobs:
         run: |
           echo "Current disk usage:"
           df -h /
-          
+
           echo "Cleaning up caches..."
           uv cache clean
           rm -rf ~/.cache/uv
@@ -374,8 +374,8 @@ jobs:
           DOCKER_IMAGES=""
           for img in $IMAGES; do
             DOCKER_IMAGES+="${img}:${IMAGE_TAG} "
-          done          
-          DOCKER_IMAGES="${DOCKER_IMAGES%" "}"          
+          done
+          DOCKER_IMAGES="${DOCKER_IMAGES%" "}"
           echo "images=$DOCKER_IMAGES" >> $GITHUB_OUTPUT
 
       - name: Scan Docker image for vulnerabilities

--- a/build-docker-image-python/action.yaml
+++ b/build-docker-image-python/action.yaml
@@ -77,15 +77,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Download Action Script
-      shell: bash -l -ET -eo pipefail {0}
-      run: |
-        curl -o action.sh \
-        -H "Authorization: Bearer ${{ inputs.py-utils-pat}}" \
-        -L "https://raw.githubusercontent.com/hawk-ai-aml/github-actions/master/build-docker-image-python/action.sh"
-
-        chmod +x action.sh
-
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -131,7 +122,7 @@ runs:
         DISABLED_CACHE: ${{ inputs.disabled-cache }}
         MODULE_ISOLATED: ${{ inputs.module-isolated }}
       run: |
-        source ./action.sh
+        source $GITHUB_ACTION_PATH/action.sh
         echo -e "${GREEN}✅ Building images for modules...${NC}"
 
         if [[ "$MODULE_ISOLATED" == "true" ]]; then
@@ -169,7 +160,7 @@ runs:
         GHCR_REGISTRY: ghcr.io/hawk-ai-aml
         DISABLED_CACHE: ${{ inputs.disabled-cache }}
       run: |
-        source ./action.sh
+        source $GITHUB_ACTION_PATH/action.sh
         echo -e "${GREEN}✅ Building images for single build...${NC}"
 
         if [ -n "$ECR_REPOSITORY" ]; then


### PR DESCRIPTION
## Description

This PR fixes a critical issue in the `build-docker-image-python` action where it attempts to download its own `action.sh` script using `curl` and a Personal Access Token (`PY_UTILS_PAT`).

### The Anti-Pattern
Composite actions should not download their own scripts over the network. When an action is executed, GitHub automatically clones the action repository to the runner's local filesystem. The script should be sourced locally using the `$GITHUB_ACTION_PATH` variable.

### The Bug
Recently, the `PY_UTILS_PAT` secret seems to have been updated to a Fine-Grained PAT restricted only to the `hawkai-py-utils` repository. Because of this scoping:
- When CI runs, `curl` uses this token in the `Authorization` header to fetch `action.sh` from the `github-actions` repository (even though it's public).
- GitHub's raw server rejects the request with a `404 Not Found` (to prevent token probing by unauthorized tokens).
- `curl` saves the "404: Not Found" HTML response into the `action.sh` file.
- The action executes `source ./action.sh`, causing bash to fail with: `./action.sh: line 1: 404:: command not found` (Exit Code 127).

### The Fix
This PR removes the fragile `curl` step completely and replaces `source ./action.sh` with `source $GITHUB_ACTION_PATH/action.sh`. This guarantees the script is correctly executed regardless of the `PY_UTILS_PAT` token's scope, environment constraints, or network availability.
